### PR TITLE
Changing landing page title to "Amazon Ion Documentation"

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-title: Amazon Ion Specification
+title: Amazon Ion Documentation
 ---
 
 # {{ page.title }}


### PR DESCRIPTION
Since the repo is for documentation (ion-docs), and since we'll eventually be hosting a cookbook and other documentation here, I think the title should include "Documentation" instead of "Specification" (since the spec is just one piece of the documentation)
