### PR TITLE
Fixing spacing inside raw blocks, adjusting whitespace on string/clob…

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -477,6 +477,7 @@ When parsing `blob` text, an error must be raised if the data:
 Within `blob` values, whitespace is ignored and comments are not allowed.
 The `/` character is always considered part of the Base64 data.
 
+```
 {% raw %}
 // A null blob value
 null.blob
@@ -501,6 +502,7 @@ null.blob
 // ERROR: Invalid character within the data.
 {{ dHdvIHBhZGRpbmc_gY2hhcmFjdGVycw= }}
 {% endraw %}
+```
 
 #### Clobs {#clob}
 
@@ -519,6 +521,7 @@ within the value.
 [Strings and Clobs](stringclob.html) gives details on the
 subtle, but profound, differences between Ion strings and clobs.
 
+```
 {% raw %}
 null.clob  // A null clob value
 
@@ -535,6 +538,7 @@ shift_jis ::
   "comments not allowed"
 }}
 {% endraw %}
+```
 
 Note that the `shift_jis` type annotation above is, like all
 [type annotations](#annot), application-defined. Ion does not interpret or
@@ -652,6 +656,7 @@ their order. Duplicate annotation symbols are allowed but discouraged.
 In the text format, type annotations are denoted by a non-null symbol
 token and double-colons preceding any content:
 
+```
 {% raw %}
 int32::12                                // Suggests 32 bits as end-user type
 'my.custom.type' :: { x : 12 , y : -1 }  // Gives a struct a user-defined type
@@ -663,6 +668,7 @@ bool :: null.int                         // A very misleading annotation on the 
 '' :: 1                                  // An empty annotation
 null.symbol :: 1                         // ERROR: type annotation cannot be null 
 {% endraw %}
+```
 
 Except for a small number of predefined system annotations, Ion itself
 neither defines nor validates such annotations; that behavior is left to

--- a/stringclob.md
+++ b/stringclob.md
@@ -102,13 +102,13 @@ splitting Unicode escapes, an escaped surrogate pair, and a common
 escape, respectively.
 
 ```
-'''\u'''    '''1234'''
+'''\u'''        '''1234'''
 
 '''\U0000'''    '''1234'''
 
 '''\uD800'''    '''\uDC00'''
 
-'''\'''    '''n'''
+'''\'''         '''n'''
 ```
 
 Within long `string` literals unescaped newlines are normalized such that
@@ -302,11 +302,13 @@ concatenated automatically. Within a `clob`, only one short string
 literal or multiple long string literals are allowed. For example, the
 following two blocks of Ion text syntax are semantically equivalent.
 
+```
 {% raw %}
-    {{ '''Hello'''    '''World''' }}
+{{ '''Hello'''    '''World''' }}
 
-    {{ "HelloWorld" }}
+{{ "HelloWorld" }}
 {% endraw %}
+```
 
 The rules for the quoted strings within a `clob` follow the similarly to
 the `string` type, except for the following exceptions. Unicode newline


### PR DESCRIPTION
… page

So while the raw tag will disable curly brace parsing, we still need to wrap those blocks in triple backticks to get proper indentation and line wrapping (pre-style formatting)
