### PR TITLE
Adding unit test to verify grammar against known-good test data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+bin
+target

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ion-tests"]
+	path = ion-tests
+	url = git@github.com:amznlabs/ion-tests.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ion-tests"]
 	path = ion-tests
-	url = git@github.com:amznlabs/ion-tests.git
+	url = https://github.com/amznlabs/ion-tests.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java
+jdk:
+  - oraclejdk8

--- a/grammar/IonText.g4
+++ b/grammar/IonText.g4
@@ -1,0 +1,628 @@
+// Ion Text 1.0 ANTLR v4 Grammar
+//
+// The following grammar does not encode all of the Ion semantics, in particular:
+//
+//   * Timestamps are syntactically defined but the rules of ISO 8601 need to be
+//     applied (especially regarding day rules with months and leap years).
+//   * Non $ion_1_0 version markers are not trapped (e.g. $ion_1_1, $ion_2_0)
+//   * Edge cases around Unicode semantics:
+//      - ANTLR specifies only four hex digit unicode escapes and on Java operates
+//        on UTF-16 code units (this is a flaw in ANTLR).
+//      - The grammar doesn't validate unpaired surrogate escapes in symbols or strings
+//        (e.g. "\udc00")
+
+grammar IonText;
+
+// note that EOF is a concept for the grammar, technically Ion streams
+// are infinite
+top_level
+    : (ws* top_level_value)* ws* value? EOF
+    ;
+
+top_level_value
+    : annotation+ top_level_value
+    | delimiting_entity
+    // numeric literals (if followed by something), need to be followed by
+    // whitespace or a token that is either quoted (e.g. string) or
+    // starts with punctuation (e.g. clob, struct, list)
+    | numeric_entity ws
+    | numeric_entity quoted_annotation value
+    | numeric_entity delimiting_entity
+    // literals that are unquoted symbols or keywords have a similar requirement
+    // as the numerics above, they have different productions because the
+    // rules for numerics are the same in s-expressions, but keywords
+    // have different rules between top-level and s-expressions.
+    | keyword_entity ws
+    | keyword_entity quoted_annotation value
+    | keyword_entity keyword_delimiting_entity
+    ;
+
+// TODO let's make sure this terminology
+// is consistent with our specification documents
+value
+    : annotation* entity
+    ;
+
+entity
+    : numeric_entity
+    | delimiting_entity
+    | keyword_entity
+    ;
+
+delimiting_entity
+    : quoted_text
+    | SHORT_QUOTED_CLOB
+    | LONG_QUOTED_CLOB
+    | BLOB
+    | list
+    | sexp
+    | struct
+    ;
+
+keyword_delimiting_entity
+    : delimiting_entity
+    | numeric_entity
+    ;
+
+keyword_entity
+    : any_null
+    | BOOL
+    | SPECIAL_FLOAT
+    | IDENTIFIER_SYMBOL
+    // note that this is because we recognize the type names for null
+    // they are ordinary symbols on their own
+    | TYPE
+    ;
+
+numeric_entity
+    : BIN_INTEGER
+    | DEC_INTEGER
+    | HEX_INTEGER
+    | TIMESTAMP
+    | FLOAT
+    | DECIMAL
+    ;
+
+annotation
+    : symbol ws* COLON COLON ws*
+    ;
+
+quoted_annotation
+    : QUOTED_SYMBOL ws* COLON COLON ws*
+    ;
+
+list
+    : L_BRACKET ws* value ws* (COMMA ws* value)* ws* (COMMA ws*)? R_BRACKET
+    | L_BRACKET ws* R_BRACKET
+    ;
+
+sexp
+    : L_PAREN (ws* sexp_value)* ws* value? R_PAREN
+    ;
+
+sexp_value
+    : annotation+ sexp_value
+    | sexp_delimiting_entity
+    | operator
+    // much like at the top level, numeric/identifiers/keywords
+    // have similar delimiting rules
+    | numeric_entity ws
+    | numeric_entity quoted_annotation value
+    | numeric_entity sexp_delimiting_entity
+    | sexp_keyword_entity ws
+    | sexp_keyword_entity quoted_annotation value
+    | sexp_keyword_entity sexp_keyword_delimiting_entity
+    | NULL ws
+    | NULL quoted_annotation value
+    | NULL sexp_null_delimiting_entity
+    ;
+
+sexp_delimiting_entity
+    : delimiting_entity
+    ;
+
+sexp_keyword_delimiting_entity
+    : sexp_delimiting_entity
+    | numeric_entity
+    | operator
+    ;
+
+sexp_null_delimiting_entity
+    : delimiting_entity
+    | NON_DOT_OPERATOR+
+    ;
+
+sexp_keyword_entity
+    : typed_null
+    | BOOL
+    | SPECIAL_FLOAT
+    | IDENTIFIER_SYMBOL
+    // note that this is because we recognize the type names for null
+    // they are ordinary symbols on their own
+    | TYPE
+    ;
+
+operator
+    : (DOT | NON_DOT_OPERATOR)+
+    ;
+
+struct
+    : L_CURLY ws* field (ws* COMMA ws* field)* ws* (COMMA ws*)? R_CURLY
+    | L_CURLY ws* R_CURLY
+    ;
+
+field
+    : field_name ws* COLON ws* annotation* entity
+    ;
+
+any_null
+    : NULL
+    | typed_null
+    ;
+
+typed_null
+    : NULL DOT NULL
+    | NULL DOT TYPE
+    ;
+
+field_name
+    : symbol
+    | SHORT_QUOTED_STRING
+    | (ws* LONG_QUOTED_STRING)+
+    ;
+
+quoted_text
+    : QUOTED_SYMBOL
+    | SHORT_QUOTED_STRING
+    | (ws* LONG_QUOTED_STRING)+
+    ;
+
+symbol
+    : IDENTIFIER_SYMBOL
+    // note that this is because we recognize the type names for null
+    // they are ordinary symbols on their own
+    | TYPE
+    | QUOTED_SYMBOL
+    ;
+
+ws
+    : WHITESPACE
+    | INLINE_COMMENT
+    | BLOCK_COMMENT
+    ;
+
+//////////////////////////////////////////////////////////////////////////////
+// Ion Punctuation
+//////////////////////////////////////////////////////////////////////////////
+
+L_BRACKET : '[';
+R_BRACKET : ']';
+L_PAREN   : '(';
+R_PAREN   : ')';
+L_CURLY   : '{';
+R_CURLY   : '}';
+COMMA     : ',';
+COLON     : ':';
+DOT       : '.';
+
+NON_DOT_OPERATOR
+    : [!#%&*+\-/;<=>?@^`|~]
+    ;
+
+//////////////////////////////////////////////////////////////////////////////
+// Ion Whitespace / Comments
+//////////////////////////////////////////////////////////////////////////////
+
+WHITESPACE
+    : WS+
+    ;
+
+INLINE_COMMENT
+    : '//' .*? (NL | EOF)
+    ;
+
+BLOCK_COMMENT
+    : '/*' .*? '*/'
+    ;
+
+//////////////////////////////////////////////////////////////////////////////
+// Ion Null
+//////////////////////////////////////////////////////////////////////////////
+
+NULL
+    : 'null'
+    ;
+
+TYPE
+    : 'bool'
+    | 'int'
+    | 'float'
+    | 'decimal'
+    | 'timestamp'
+    | 'symbol'
+    | 'string'
+    | 'clob'
+    | 'blob'
+    | 'list'
+    | 'sexp'
+    | 'struct'
+    ;
+
+//////////////////////////////////////////////////////////////////////////////
+// Ion Bool
+//////////////////////////////////////////////////////////////////////////////
+
+BOOL
+    : 'true'
+    | 'false'
+    ;
+
+//////////////////////////////////////////////////////////////////////////////
+// Ion Timestamp
+//////////////////////////////////////////////////////////////////////////////
+
+TIMESTAMP
+    : DATE ('T' TIME?)?
+    | YEAR '-' MONTH 'T'
+    | YEAR 'T'
+    ;
+
+fragment
+DATE
+    : YEAR '-' MONTH '-' DAY
+    ;
+
+fragment
+YEAR
+    : '000'                     [1-9]
+    | '00'            [1-9]     DEC_DIGIT
+    | '0'   [1-9]     DEC_DIGIT DEC_DIGIT
+    | [1-9] DEC_DIGIT DEC_DIGIT DEC_DIGIT
+    ;
+
+fragment
+MONTH
+    : '0' [1-9]
+    | '1' [0-2]
+    ;
+
+fragment
+DAY
+    : '0'   [1-9]
+    | [1-2] DEC_DIGIT
+    | '3'   [0-1]
+    ;
+
+fragment
+TIME
+    : HOUR ':' MINUTE (':' SECOND)? OFFSET
+    ;
+
+fragment
+OFFSET
+    : 'Z'
+    | PLUS_OR_MINUS HOUR ':' MINUTE
+    ;
+
+fragment
+HOUR
+    : [01] DEC_DIGIT
+    | '2' [0-3]
+    ;
+
+fragment
+MINUTE
+    : [0-5] DEC_DIGIT
+    ;
+
+// note that W3C spec requires a digit after the '.'
+fragment
+SECOND
+    : [0-5] DEC_DIGIT ('.' DEC_DIGIT+)?
+    ;
+
+//////////////////////////////////////////////////////////////////////////////
+// Ion Int
+//////////////////////////////////////////////////////////////////////////////
+
+BIN_INTEGER
+    : '-'? '0' [bB] BINARY_DIGIT (UNDERSCORE? BINARY_DIGIT)*
+    ;
+
+DEC_INTEGER
+    : '-'? DEC_UNSIGNED_INTEGER
+    ;
+
+HEX_INTEGER
+    : '-'? '0' [xX] HEX_DIGIT (UNDERSCORE? HEX_DIGIT)*
+    ;
+
+//////////////////////////////////////////////////////////////////////////////
+// Ion Float
+//////////////////////////////////////////////////////////////////////////////
+
+SPECIAL_FLOAT
+    : PLUS_OR_MINUS 'inf'
+    | 'nan'
+    ;
+
+FLOAT
+    : DEC_INTEGER DEC_FRAC? FLOAT_EXP
+    ;
+
+fragment
+FLOAT_EXP
+    : [Ee] PLUS_OR_MINUS? DEC_DIGIT+
+    ;
+
+//////////////////////////////////////////////////////////////////////////////
+// Ion Decimal
+//////////////////////////////////////////////////////////////////////////////
+
+DECIMAL
+    : DEC_INTEGER DEC_FRAC? DECIMAL_EXP?
+    ;
+
+fragment
+DECIMAL_EXP
+    : [Dd] PLUS_OR_MINUS? DEC_DIGIT+
+    ;
+
+//////////////////////////////////////////////////////////////////////////////
+// Ion Symbol
+//////////////////////////////////////////////////////////////////////////////
+
+QUOTED_SYMBOL
+    : SYMBOL_QUOTE SYMBOL_TEXT SYMBOL_QUOTE
+    ;
+
+fragment
+SYMBOL_TEXT
+    : (TEXT_ESCAPE | SYMBOL_TEXT_ALLOWED)*
+    ;
+
+// non-control Unicode and not single quote or backslash
+fragment
+SYMBOL_TEXT_ALLOWED
+    : '\u0020'..'\u0026' // no C1 control characters and no U+0027 single quote
+    | '\u0028'..'\u005B' // no U+005C backslash
+    | '\u005D'..'\uFFFF' // should be up to U+10FFFF
+    ;
+
+IDENTIFIER_SYMBOL
+    : [$_a-zA-Z] ([$_a-zA-Z] | DEC_DIGIT)*
+    ;
+
+//////////////////////////////////////////////////////////////////////////////
+// Ion String
+//////////////////////////////////////////////////////////////////////////////
+
+SHORT_QUOTED_STRING
+    : SHORT_QUOTE STRING_SHORT_TEXT SHORT_QUOTE
+    ;
+
+LONG_QUOTED_STRING
+    : LONG_QUOTE STRING_LONG_TEXT LONG_QUOTE
+    ;
+
+
+fragment
+STRING_SHORT_TEXT
+    : (TEXT_ESCAPE | STRING_SHORT_TEXT_ALLOWED)*
+    ;
+
+fragment
+STRING_LONG_TEXT
+    : (TEXT_ESCAPE | STRING_LONG_TEXT_ALLOWED)*?
+    ;
+
+// non-control Unicode and not double quote or backslash
+fragment
+STRING_SHORT_TEXT_ALLOWED
+    : '\u0020'..'\u0021' // no C1 control characters and no U+0022 double quote
+    | '\u0023'..'\u005B' // no U+005C backslash
+    | '\u005D'..'\uFFFF' // FIXME should be up to U+10FFFF
+    ;
+
+// non-control Unicode (newlines are OK)
+fragment
+STRING_LONG_TEXT_ALLOWED
+    : '\u0020'..'\u005B' // no C1 control characters and no U+005C blackslash
+    | '\u005D'..'\uFFFF' // FIXME should be up to U+10FFFF
+    | NL
+    ;
+
+fragment
+TEXT_ESCAPE
+    : COMMON_ESCAPE | HEX_ESCAPE | UNICODE_ESCAPE
+    ;
+
+//////////////////////////////////////////////////////////////////////////////
+// Ion CLOB
+//////////////////////////////////////////////////////////////////////////////
+
+SHORT_QUOTED_CLOB
+    : LOB_START WS* SHORT_QUOTE CLOB_SHORT_TEXT SHORT_QUOTE WS* LOB_END
+    ;
+
+LONG_QUOTED_CLOB
+    : LOB_START (WS* LONG_QUOTE CLOB_LONG_TEXT*? LONG_QUOTE)+ WS* LOB_END
+    ;
+
+fragment
+CLOB_SHORT_TEXT
+    : (CLOB_ESCAPE | CLOB_SHORT_TEXT_ALLOWED)*
+    ;
+
+fragment
+CLOB_LONG_TEXT
+    : CLOB_LONG_TEXT_NO_QUOTE
+    | '\'' CLOB_LONG_TEXT_NO_QUOTE
+    | '\'\'' CLOB_LONG_TEXT_NO_QUOTE
+    ;
+
+fragment
+CLOB_LONG_TEXT_NO_QUOTE
+    : (CLOB_ESCAPE | CLOB_LONG_TEXT_ALLOWED)
+    ;
+
+// non-control ASCII and not double quote or backslash
+fragment
+CLOB_SHORT_TEXT_ALLOWED
+    : '\u0020'..'\u0021' // no U+0022 double quote
+    | '\u0023'..'\u005B' // no U+005C backslash
+    | '\u005D'..'\u007E'
+    ;
+
+// non-control ASCII (newlines are OK)
+fragment
+CLOB_LONG_TEXT_ALLOWED
+    : '\u0020'..'\u0026' // no U+0027 single quote
+    | '\u0028'..'\u005B' // no U+005C blackslash
+    | '\u005D'..'\u007E'
+    | NL
+    ;
+
+fragment
+CLOB_ESCAPE
+    : COMMON_ESCAPE | HEX_ESCAPE
+    ;
+
+//////////////////////////////////////////////////////////////////////////////
+// Ion BLOB
+//////////////////////////////////////////////////////////////////////////////
+
+BLOB
+    : LOB_START (BASE_64_QUARTET | WS)* BASE_64_PAD? WS* LOB_END
+    ;
+
+fragment
+BASE_64_PAD
+    : BASE_64_PAD1
+    | BASE_64_PAD2
+    ;
+
+fragment
+BASE_64_QUARTET
+    : BASE_64_CHAR WS* BASE_64_CHAR WS* BASE_64_CHAR WS* BASE_64_CHAR
+    ;
+
+fragment
+BASE_64_PAD1
+    : BASE_64_CHAR WS* BASE_64_CHAR WS* BASE_64_CHAR WS* '='
+    ;
+
+fragment
+BASE_64_PAD2
+    : BASE_64_CHAR WS* BASE_64_CHAR WS* '=' WS* '='
+    ;
+
+fragment
+BASE_64_CHAR
+    : [0-9a-zA-Z+/]
+    ;
+
+//////////////////////////////////////////////////////////////////////////////
+// Common Lexer Primitives
+//////////////////////////////////////////////////////////////////////////////
+
+fragment LOB_START    : '{{';
+fragment LOB_END      : '}}';
+fragment SYMBOL_QUOTE : '\'';
+fragment SHORT_QUOTE  : '"';
+fragment LONG_QUOTE   : '\'\'\'';
+
+// Ion does not allow leading zeros for base-10 numbers
+fragment
+DEC_UNSIGNED_INTEGER
+    : '0'
+    | [1-9] (UNDERSCORE? DEC_DIGIT)*
+    ;
+
+fragment
+DEC_FRAC
+    : '.'
+    | '.' DEC_DIGIT (UNDERSCORE? DEC_DIGIT)*
+    ;
+
+fragment
+DEC_DIGIT
+    : [0-9]
+    ;
+
+fragment
+HEX_DIGIT
+    : [0-9a-fA-F]
+    ;
+
+fragment
+BINARY_DIGIT
+    : [01]
+    ;
+
+fragment
+PLUS_OR_MINUS
+    : [+\-]
+    ;
+
+fragment
+COMMON_ESCAPE
+    : '\\' COMMON_ESCAPE_CODE
+    ;
+
+fragment
+COMMON_ESCAPE_CODE
+    : 'a'
+    | 'b'
+    | 't'
+    | 'n'
+    | 'f'
+    | 'r'
+    | 'v'
+    | '?'
+    | '0'
+    | '\''
+    | '"'
+    | '/'
+    | '\\'
+    | NL
+    ;
+
+fragment
+HEX_ESCAPE
+    : '\\x' HEX_DIGIT HEX_DIGIT
+    ;
+
+fragment
+UNICODE_ESCAPE
+    : '\\u'     HEX_DIGIT_QUARTET
+    | '\\U000'  HEX_DIGIT_QUARTET HEX_DIGIT 
+    | '\\U0010' HEX_DIGIT_QUARTET
+    ;
+
+fragment
+HEX_DIGIT_QUARTET
+    : HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT
+    ;
+
+fragment
+WS
+    : '\u0009' // tab
+    | '\u000A' // line feed
+    | '\u000B' // vertical tab
+    | '\u000C' // form feed
+    | '\u000D' // carriage return
+    | '\u0020' // space
+    ;
+
+fragment
+NL
+    : '\u000D\u000A'  // carriage return + line feed
+    | '\u000D'        // carriage return
+    | '\u000A'        // line feed
+    ;
+
+fragment
+UNDERSCORE
+    : '_'
+    ;

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,63 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>software.amazon</groupId>
+  <artifactId>ion-docs</artifactId>
+  <version>1.0.0</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.antlr</groupId>
+      <artifactId>antlr4-runtime</artifactId>
+      <version>4.5.3</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.19.1</version>
+        <configuration>
+          <systemPropertyVariables>
+            <iontestdata.path>${basedir}/ion-tests/iontestdata</iontestdata.path>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.antlr</groupId>
+        <artifactId>antlr4-maven-plugin</artifactId>
+        <version>4.3</version>
+        <executions>
+          <execution>
+            <id>antlr</id>
+            <phase>generate-sources</phase>
+            <configuration>
+              <outputDirectory>${project.build.directory}/generated-sources/antlr4</outputDirectory>
+              <sourceDirectory>${basedir}/grammar</sourceDirectory>
+            </configuration>
+            <goals>
+              <goal>antlr4</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/java/GrammarTest.java
+++ b/src/test/java/GrammarTest.java
@@ -1,0 +1,270 @@
+
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.MalformedInputException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.antlr.v4.runtime.ANTLRErrorListener;
+import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.TokenStream;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Simple driver for recognizing and diagnosing Ion via the ANTLR defined grammar.
+ */
+@RunWith(Parameterized.class)
+public final class GrammarTest {
+    private static final String TEST_DATA_PATH_PROPERTY = "iontestdata.path";
+    private static final File TEST_DATA_DIR;
+    static {
+        final String path = System.getProperty(TEST_DATA_PATH_PROPERTY);
+        if (path == null) {
+            throw new IllegalStateException(TEST_DATA_PATH_PROPERTY + " must be set");
+        }
+        TEST_DATA_DIR = new File(path);
+        if (!TEST_DATA_DIR.isDirectory()) {
+            throw new IllegalStateException(TEST_DATA_PATH_PROPERTY + " is not a directory: " + TEST_DATA_DIR);
+        }
+    }
+
+    private static File testPath(final String name) {
+        return new File(TEST_DATA_DIR, name);
+    }
+
+    private static final Set<File> SKIP_FILES;
+    static {
+        final Set<File> skip = new HashSet<>();
+
+        // TODO add validation code for non-annotated top-level non 1.0 IVMs
+        skip.add(testPath("bad/invalidVersionMarker_ion_0_0.ion"));
+        skip.add(testPath("bad/invalidVersionMarker_ion_1234_0.ion"));
+        skip.add(testPath("bad/invalidVersionMarker_ion_1_1.ion"));
+        skip.add(testPath("bad/invalidVersionMarker_ion_2_0.ion"));
+        // TODO add validation around Unicode escapes
+        skip.add(testPath("bad/utf8/surrogate_5.ion"));
+
+        // ANTLR test driver does not test UTF-16 or UTF-32
+        skip.add(testPath("good/utf16.ion"));
+        skip.add(testPath("good/utf32.ion"));
+
+        SKIP_FILES = Collections.unmodifiableSet(skip);
+    }
+
+    public enum FileType {
+        BAD,
+        GOOD,
+    }
+
+    private static Object[] array(final Object... vals) {
+        return vals;
+    }
+
+    private static void addTextFiles(final List<Object[]> params, final File directory, final FileType type) {
+        final File[] entries = directory.listFiles();
+        if (entries == null) {
+            throw new IllegalStateException("Not a directory: " + directory);
+        }
+        for (final File entry : entries) {
+            if (entry.isDirectory()) {
+                addTextFiles(params, entry, type);
+            } else if (entry.getName().endsWith(".ion") && !SKIP_FILES.contains(entry)) {
+                params.add(array(entry, type));
+            }
+        }
+    }
+
+    @Parameters(name = "{1}: {0}")
+    public static Collection<Object[]> parameters() {
+        final List<Object[]> params = new ArrayList<>();
+        addTextFiles(params, new File(TEST_DATA_DIR, "good"), FileType.GOOD);
+        addTextFiles(params, new File(TEST_DATA_DIR, "bad"), FileType.BAD);
+        return params;
+    }
+
+    @Parameter(0)
+    public File file;
+
+    @Parameter(1)
+    public FileType type;
+
+    private static final class AntlrError {
+        public final int line;
+        public final int pos;
+        public final String msg;
+
+        public AntlrError(final int line, final int pos, final String msg) {
+            this.line = line;
+            this.pos = pos;
+            this.msg = msg;
+        }
+
+        @Override
+        public String toString() {
+            return "line " + line + ":" + pos + " - " + msg;
+        }
+    }
+
+    private static final class AntlrErrorException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+        public final AntlrError error;
+
+        public AntlrErrorException(AntlrError error) {
+            this.error = error;
+        }
+    }
+
+    private static final int[] MONTH_DAY_MAXIMUMS = {
+        31, // JAN
+        28, // FEB
+        31, // MAR
+        30, // APR
+        31, // MAY
+        30, // JUN
+        31, // JUL
+        31, // AUG
+        30, // SEP
+        31, // OCT
+        30, // NOV
+        31  // DEC
+    };
+
+    private static final int YEAR_POSITION                  = 0;
+    private static final int MONTH_POSITION                 = 5;
+    private static final int DAY_POSITION                   = 8;
+    private static final int DAY_RESOLUTION_MIN_LENGTH      = 10;
+
+    private static int parseIntField(final String text, final int position, final int length) {
+        return Integer.parseInt(text.substring(position, position + length), 10);
+    }
+
+    private static boolean isLeapYear(final int year) {
+        // from RFC-3339
+        return (year % 4 == 0 && (year % 100 != 0 || year % 400 == 0));
+    }
+
+    /** Validates the day of month semantics for timestamp. */
+    private static void validateTimestamp(final String text) {
+        final int length = text.length();
+        if (length >= DAY_RESOLUTION_MIN_LENGTH) {
+            final int year  = parseIntField(text, YEAR_POSITION, 4);
+            final int month = parseIntField(text, MONTH_POSITION, 2);
+            final int day   = parseIntField(text, DAY_POSITION, 2);
+
+            if (isLeapYear(year) && month == 2) {
+                if (day > 29) {
+                    throw new IllegalStateException("Invalid day number: " + text);
+                }
+            } else {
+                if (day > MONTH_DAY_MAXIMUMS[month - 1]) {
+                    throw new IllegalStateException("Invalid day number: " + text);
+                }
+            }
+        }
+    }
+
+    /**
+     * Performs additional validation on the grammar.
+     * In particular, this does Timestamp verification.
+     */
+    private static final class IonTextValidatingListener extends IonTextBaseListener {
+        @Override
+        public void visitTerminal(final TerminalNode node) {
+            final Token token = node.getSymbol();
+            final String text = node.getText();
+            try {
+                switch (token.getType()) {
+                case IonTextLexer.TIMESTAMP:
+                    validateTimestamp(text);
+                    break;
+                default:
+                    // ignore
+                }
+            } catch (final Exception e) {
+                throw new AntlrErrorException(new AntlrError(token.getLine(), token.getStartIndex(), e.getMessage()));
+            }
+        }
+    }
+
+    @Test
+    public void parse() throws Exception {
+        final CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
+        decoder.onMalformedInput(CodingErrorAction.REPORT);
+        decoder.onUnmappableCharacter(CodingErrorAction.REPORT);
+        try (final Reader in = new InputStreamReader(new FileInputStream(file), decoder)) {
+            final List<AntlrError> errors = new ArrayList<>();
+            try {
+                final CharStream chars = new ANTLRInputStream(in);
+                final IonTextLexer lexer = new IonTextLexer(chars);
+                final TokenStream stream = new CommonTokenStream(lexer);
+                final IonTextParser parser = new IonTextParser(stream);
+
+                final ANTLRErrorListener listener = new BaseErrorListener() {
+                    @Override
+                    public void syntaxError(final Recognizer<?, ?> recognizer,
+                                            final Object offendingSymbol,
+                                            final int line,
+                                            final int charPositionInLine,
+                                            final String msg,
+                                            final RecognitionException e) {
+                        errors.add(new AntlrError(line, charPositionInLine, msg));
+                    }
+                };
+                lexer.removeErrorListeners();
+                parser.removeErrorListeners();
+                lexer.addErrorListener(listener);
+                parser.addErrorListener(listener);
+
+                // parse!
+                final ParseTree tree = parser.top_level();
+
+                // intercept
+                ParseTreeWalker walker = new ParseTreeWalker();
+                walker.walk(new IonTextValidatingListener(), tree);
+            } catch (final AntlrErrorException e) {
+                errors.add(e.error);
+            } catch (final MalformedInputException e) {
+                errors.add(new AntlrError(-1, -1, e.getMessage()));
+            }
+
+            // check for errors
+            switch (type) {
+            case GOOD:
+                if (!errors.isEmpty()) {
+                    fail("Unexpected failure: " + errors);
+                }
+                break;
+            case BAD:
+                if (errors.isEmpty()) {
+                    fail("Expected a error!");
+                }
+                break;
+            default:
+                throw new IllegalStateException("Unknown type: " + type);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is just a copy-paste of our internal logic.

Antlr insists that the grammar name be the same as the grammar file minus the .g4 extension, so I've renamed the file to remove the .txt extension. The negative side effect is that when you try to view the grammar on our website you'll get a download instead of just viewing it inline since it's no longer considered text. A follow-up change to augment the mime type database used by Github Pages will fix the issue.
