### PR TITLE
Small clarification regarding unknown symbol text.

### DIFF
--- a/symbols.md
+++ b/symbols.md
@@ -525,10 +525,10 @@ hold:
     calculated from the SIDs by the allocation algorithm above.
 * SID 0 is only equivalent to itself.
 
-A processor encountering a symbol with *unknown* text other than `$0` MAY
-produce an error because this means that the context of the data is missing,
-however any implementation that chooses not to MUST conform to the above semantics
-with respect to round-tripping data.
+A processor encountering a symbol with *unknown* text *and* a valid SID other
+than `$0` MAY produce an error because this means that the context of the data is
+missing, however any implementation that chooses not to MUST conform to the above
+semantics with respect to round-tripping data.
 
 Examples
 --------


### PR DESCRIPTION
When I read this passage, I thought it contradicted this one:

“Any symbol ID outside of the range of the local symbol table (or system symbol table if no local symbol table is defined) for which it is encoded under MUST raise an error.”

I think pointing out that symbols with unknown text must have valid symbol IDs helps to make the distinction. If you think we need to define "valid symbol ID" (symbol ID within the max_id range of the active local and/or shared table), we can add that too.