### PR TITLE
Fixes timestamp example with swapped exponent and coefficient.

### DIFF
--- a/binary.md
+++ b/binary.md
@@ -405,7 +405,7 @@ following hex encoded timestamps are equivalent:
 69 80 0F D0 81 81 80 80 80 80    // The same instant with 0d0 fractional seconds and implicit zero coefficient
 6A 80 0F D0 81 81 80 80 80 80 00 // The same instant with 0d0 fractional seconds and explicit zero coefficient
 69 80 0F D0 81 81 80 80 80 C0    // The same instant with 0d-0 fractional seconds
-69 80 0F D0 81 81 80 80 80 81    // The same instant with 0d1 fractional seconds
+69 80 0F D0 81 81 80 80 81 80    // The same instant with 0d1 fractional seconds
 ```
 
 Conversely, none of the following are equivalent:


### PR DESCRIPTION
A contributor stumbled on our example, and I verified that it is not correct (both mentally and with the following Kotlin code):

```kotlin
fun decimal() {
    val value = ion.singleValue(
        listOf(
            0xE0, 0x01, 0x00, 0xEA,
            0x52, 0x80, 0x81
        ).map { it.toByte() }.toByteArray()
    )
    println(value)
}
```
The above prints `-1.`

```kotlin
fun decimal() {
    val value = ion.singleValue(
        listOf(
            0xE0, 0x01, 0x00, 0xEA,
            0x52, 0x81, 0x80
        ).map { it.toByte() }.toByteArray()
    )
    println(value)
}
```

The above prints the expected `-0d1`.