### PR TITLE
Specify inapplicable Hursley Decimal String rules

### DIFF
--- a/decimal.md
+++ b/decimal.md
@@ -31,10 +31,11 @@ forms of positive zero, also are distinguished only by the *exponent*.
 
 ### Text Format
 
-The Hursley rules for [converting from textual notation][3] *must* be followed with the following exceptions.
+The Hursley rules for describing a _finite value_ [converting from textual notation][3] *must* be followed. 
+The Hursley rules for describing a _special value_ are **not** followed--the rules for 
 
-* `infinity`  -- this Hursley rule is **not** applicable for Ion Decimals.
-* `nan`       -- this Hursley rule is **not** applicable for Ion Decimals
+* `infinity`  -- rule is **not** applicable for Ion Decimals.
+* `nan`       -- rule is **not** applicable for Ion Decimals
 
 Specifically, the rules for getting the integer *coefficient* from the
 *decimal-part* (digits preceding the exponent) of the textual representation


### PR DESCRIPTION
To avoid confusion, clarify which Numeric String syntax rules from Hursley are invalid for Ion Decimals