### PR TITLE
Adds exponent symbol to Ion C 1.0 release

### DIFF
--- a/_posts/2018-04-12-ion-c-1_0_0-released.md
+++ b/_posts/2018-04-12-ion-c-1_0_0-released.md
@@ -14,6 +14,6 @@ Highlighted features:
 Limitations:
 
 * No UTF-16 or UTF-32 support.
-* Binary Ion streams may not exceed 2^32 distinct symbols.
+* Binary Ion streams may not exceed 2<sup>32</sup> distinct symbols.
 
 | [Release Notes](https://github.com/amzn/ion-c/releases/tag/v1.0.0) |


### PR DESCRIPTION
2^32, not 232.