### PR TITLE
Adds ion-python 0.3.0 release to news/libs.

### DIFF
--- a/_posts/2018-05-15-ion-python-0_3_0-released.md
+++ b/_posts/2018-05-15-ion-python-0_3_0-released.md
@@ -1,0 +1,9 @@
+---
+layout: news_item
+title: "Ion Python 0.3.0 Released"
+date: 2018-05-15 17:30:00 -0700
+categories: news ion-python
+---
+Adds support for binary and text in `simpleion.loads()` and `simpleion.dumps()`.
+
+| [Release Notes](https://github.com/amzn/ion-python/releases/tag/v0.3.0) |

--- a/libs.md
+++ b/libs.md
@@ -10,7 +10,7 @@ description: "The latest news about Amazon Ion and the Amazon Ion community."
 | Name | Latest Version | Repository | Documentation |
 |------|----------------|------|---------------|
 | ion-java | [1.1.2](https://github.com/amzn/ion-java/releases/latest) (April 2, 2018) | [Link](https://github.com/amzn/ion-java) | [Link](https://www.javadoc.io/doc/software.amazon.ion/ion-java/) |
-|ion-python | [0.2.0](https://github.com/amzn/ion-python/releases/latest) (May 10, 2017) | [Link](https://github.com/amzn/ion-python) | - |
+|ion-python | [0.3.0](https://github.com/amzn/ion-python/releases/latest) (May 15, 2018) | [Link](https://github.com/amzn/ion-python) | - |
 | ion-c | [1.0.0](https://github.com/amzn/ion-c/releases/latest) (April 12, 2018) | [Link](https://github.com/amzn/ion-c) | - |
 | ion-js | Currently in Alpha | [Link](https://github.com/amzn/ion-js) | [Link](https://amzn.github.io/ion-js/api/) |
 


### PR DESCRIPTION
Tested with local Jekyll.