### PR TITLE
Adds Ion C 1.0.1 and Ion Java 1.2.0 news

### DIFF
--- a/_posts/2018-03-23-ion-java-1_1_1-released.md
+++ b/_posts/2018-03-23-ion-java-1_1_1-released.md
@@ -4,6 +4,6 @@ title: "Ion Java 1.1.1 Released"
 date: 2018-03-23 12:38:00 -0800
 categories: news
 ---
-Fixes `IonStruct.clone` performance regression introduced in v1.1.0
+Fixes `IonStruct.clone` performance regression introduced in v1.1.0.
 
 | [Release Notes](https://github.com/amzn/ion-java/releases/tag/v1.1.1) |

--- a/_posts/2018-04-02-ion-java-1_1_2-released.md
+++ b/_posts/2018-04-02-ion-java-1_1_2-released.md
@@ -4,6 +4,6 @@ title: "Ion Java 1.1.2 Released"
 date: 2018-04-02 13:44:00 -0800
 categories: news
 ---
-Javadoc changes
+Javadoc changes.
 
 | [Release Notes](https://github.com/amzn/ion-java/releases/tag/v1.1.2) |

--- a/_posts/2018-05-25-ion-c-1_0_1-released.md
+++ b/_posts/2018-05-25-ion-c-1_0_1-released.md
@@ -1,0 +1,11 @@
+---
+layout: news_item
+title: "Ion C 1.0.1 Released"
+date: 2018-05-25 16:56:00 -0800
+categories: news
+---
+Bug fixes:
+
+* Fixed an issue that caused release builds to fail during linking.
+
+| [Release Notes](https://github.com/amzn/ion-c/releases/tag/v1.0.1) |

--- a/_posts/2018-06-22-ion-java-1_2_0-released.md
+++ b/_posts/2018-06-22-ion-java-1_2_0-released.md
@@ -1,0 +1,10 @@
+---
+layout: news_item
+title: "Ion Java 1.2.0 Released"
+date: 2018-06-22 12:10:00 -0800
+categories: news
+---
+* Decouples IonReader from IonSystem and adds IonReaderBuilder
+* Add Automatic-Module-Name in manifest so Java9 modular applications can depend on this library
+
+| [Release Notes](https://github.com/amzn/ion-java/releases/tag/v1.2.0) |

--- a/_posts/2018-06-22-ion-java-1_2_0-released.md
+++ b/_posts/2018-06-22-ion-java-1_2_0-released.md
@@ -4,7 +4,7 @@ title: "Ion Java 1.2.0 Released"
 date: 2018-06-22 12:10:00 -0800
 categories: news
 ---
-* Decouples IonReader from IonSystem and adds IonReaderBuilder
-* Add Automatic-Module-Name in manifest so Java9 modular applications can depend on this library
+* Decouples IonReader from IonSystem and adds IonReaderBuilder.
+* Adds Automatic-Module-Name in manifest so Java9 modular applications can depend on this library.
 
 | [Release Notes](https://github.com/amzn/ion-java/releases/tag/v1.2.0) |

--- a/libs.md
+++ b/libs.md
@@ -9,9 +9,9 @@ description: "The latest news about Amazon Ion and the Amazon Ion community."
 
 | Name | Latest Version | Repository | Documentation |
 |------|----------------|------|---------------|
-| ion-java | [1.1.2](https://github.com/amzn/ion-java/releases/latest) (April 2, 2018) | [Link](https://github.com/amzn/ion-java) | [Link](https://www.javadoc.io/doc/software.amazon.ion/ion-java/) |
+| ion-java | [1.2.0](https://github.com/amzn/ion-java/releases/latest) (June 22, 2018) | [Link](https://github.com/amzn/ion-java) | [Link](https://www.javadoc.io/doc/software.amazon.ion/ion-java/) |
 |ion-python | [0.3.1](https://github.com/amzn/ion-python/releases/latest) (May 15, 2018) | [Link](https://github.com/amzn/ion-python) | - |
-| ion-c | [1.0.0](https://github.com/amzn/ion-c/releases/latest) (April 12, 2018) | [Link](https://github.com/amzn/ion-c) | - |
+| ion-c | [1.0.1](https://github.com/amzn/ion-c/releases/latest) (May 25, 2018) | [Link](https://github.com/amzn/ion-c) | - |
 | ion-js | Currently in Alpha | [Link](https://github.com/amzn/ion-js) | [Link](https://amzn.github.io/ion-js/api/) |
 
 ## Ion Team Supported Tools


### PR DESCRIPTION
There were 2 new versions of libraries added that have not been updated.

* Ion C 1.0.1 on May 25, 2018
* Ion Java 1.2.0 on June 22, 2018

I was debating on whether the Ion C change deserved a news item, but I think defaulting to adding more news for our community is better.