### PR TITLE
Clarifies that symbol IDs with unknown text from local symbol tables are equivalent to symbol zero.

### DIFF
--- a/docs/symbols.md
+++ b/docs/symbols.md
@@ -497,10 +497,10 @@ Equivalently:
 
 Symbol Zero
 -----------
-The special SID zero (i.e. `$0`) represents special symbol that is not defined by
-any symbol table, even the system symbol table.  Symbol zero always has undefined
-text, and can be useful in synthesizing symbol identifiers where the text image of the
-symbol is not known in a particular operating context.
+SID zero (i.e. `$0`) is a special symbol that is not assigned text by any symbol
+table, even the system symbol table. Symbol zero always has unknown text, and can
+be useful in synthesizing symbol identifiers where the text image of the symbol is
+not known in a particular operating context.
 
 It is important to note that `$0` is only semantically equivalent to itself and to
 locally-declared SIDs with unknown text. It is not semantically equivalent to SIDs


### PR DESCRIPTION
Symbol IDs with unknown text that point to slots in shared symbol tables may later become defined if, for example, the import was missing but is now resolved.

In local symbol tables, however, it is impossible for a symbol ID pointing to a slot with undefined text (i.e. a "null slot") to later have defined text. As a result, treating all such symbol IDs as symbol zero is not a destructive operation.

Further, it simplifies symbol token processing logic. With the change, the local symbol ID is no longer needed to define a SymbolToken structure capable of correctly implementing the equivalence semantics defined by the spec (for elaboration, see the [developers' guide to symbols](http://amzn.github.io/ion-docs/guides/symbols-guide.html)). Additionally, it removes the requirement for null slots to be preserved when rountripping; all null slots can be removed and their symbol IDs reassigned to zero.