### PR TITLE
Fixes a broken no-op IVM example in symbols.md.

### DIFF
--- a/docs/symbols.md
+++ b/docs/symbols.md
@@ -180,6 +180,8 @@ of IVMs mixed with these NOP encodings:
     '$ion_1_0'
     // also not the IVM
     $2
+    // maps to "a"
+    $10
 
 The above is equivalent to the following, more concise Ion:
 


### PR DESCRIPTION
The text below the example says it is equivalent to 
```
$ion_1_0
a
```
but before this change, the symbol identifier representing `a` ($10) was missing.