### PR TITLE
Adds C examples to the Cookbook

### DIFF
--- a/guides/cookbook.md
+++ b/guides/cookbook.md
@@ -135,8 +135,7 @@ The following example shows how data can be written to a buffer as Ion text:
 #define ION_OK(x) if (x) { printf("Error: %s\n", ion_error_to_str(x)); return x; }
 
 int main(int argc, char **argv) {
-    const char *ion_text = (char *)malloc(200);
-
+    char ion_text[200];
     hWRITER writer;
     ION_WRITER_OPTIONS options;
 


### PR DESCRIPTION
Adds example ion-c usage; punting on the shared symbol table examples for now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
