### PR TITLE
Adds C# examples to the Cookbook

### DIFF
--- a/guides/cookbook.md
+++ b/guides/cookbook.md
@@ -184,7 +184,7 @@ class ReadIonData
 {
     static void Main(string[] args)
     {
-        IIonReader reader = IonReaderBuilder.Build("{hello: \"world\"}");
+        using IIonReader reader = IonReaderBuilder.Build("{hello: \"world\"}");
         reader.MoveNext();                           // position the reader at the first value, a struct
         reader.StepIn();                             // step into the struct
         reader.MoveNext();                           // position the reader at the first value in the struct
@@ -483,7 +483,7 @@ class PrettyPrint
 {
     static void Main(string[] args)
     {
-        IIonReader reader = IonReaderBuilder.Build("{level1: {level2: {level3: \"foo\"}, x: 2}, y: [a,b,c]}");
+        using IIonReader reader = IonReaderBuilder.Build("{level1: {level2: {level3: \"foo\"}, x: 2}, y: [a,b,c]}");
 
         using TextWriter tw = new StringWriter();
         using IIonWriter writer = IonTextWriterBuilder.Build(tw, new IonTextOptions {PrettyPrint = true});
@@ -770,7 +770,7 @@ class ReadNumericValues
         BigInteger third = BigInteger.Parse("123456");
         BigInteger fourth = BigInteger.Parse("12345678901234567890");
 
-        IIonReader reader = IonReaderBuilder.Build(numberList);
+        using IIonReader reader = IonReaderBuilder.Build(numberList);
         Debug.Assert(reader.MoveNext() == IonType.Decimal);
         Debug.Assert(first == reader.DecimalValue());
         Debug.Assert(first.ToDecimal() == reader.DecimalValue().ToDecimal());
@@ -1007,7 +1007,7 @@ class SparseReads
             0x67, 0x31, 0x86, 0x74, 0x68, 0x69, 0x6e, 0x67, 0x32, 0xe6, 0x81, 0x8a, 0xd3, 0x8b,
             0x21, 0x13, 0xe9, 0x81, 0x8c, 0xd6, 0x84, 0x81, 0x79, 0x8d, 0x21, 0x08 };
 
-        IIonReader reader = IonReaderBuilder.Build(bytes);
+        using IIonReader reader = IonReaderBuilder.Build(bytes);
         int sum = 0;
         IonType type;
         while ((type = reader.MoveNext()) != IonType.None)

--- a/guides/cookbook.md
+++ b/guides/cookbook.md
@@ -197,7 +197,7 @@ class ReadIonData
 ```
 
 In the above example, the text Ion `{hello: "world"}` was probably typed by a human using a text
-editor. The following example illustrates how it could have been generated using an IIonWriter:
+editor. The following example illustrates how it could have been generated using an `IIonWriter`:
 
 ```c#
 using IonDotnet;
@@ -209,8 +209,8 @@ class WriteIonText
 {
     static void Main(string[] args)
     {
-        TextWriter tw = new StringWriter();
-        IIonWriter writer = IonTextWriterBuilder.Build(tw);
+        using TextWriter tw = new StringWriter();
+        using IIonWriter writer = IonTextWriterBuilder.Build(tw);
         writer.StepIn(IonType.Struct);     // step into a struct
         writer.SetFieldName("hello");      // set the field name for the next value to be written
         writer.WriteString("world");       // write the next value
@@ -221,7 +221,7 @@ class WriteIonText
 }
 ```
 
-If the desired output is pretty text, pass an instance of `IonTextOptions` with `PrettyPrint` set to `true` to `IonTextWriterBuilder.Build()`.    If Ion binary encoding is desired, use `IonBinaryWriterBuilder` (instead of `IonTextWriterBuilder`).
+If Ion binary encoding is desired, use `IonBinaryWriterBuilder` (instead of `IonTextWriterBuilder`).
 </div>
 
 <div class="tabpane Java" markdown="1">
@@ -386,9 +386,8 @@ writer.close();                      // close the writer
 console.log(String.fromCharCode.apply(null, writer.getBytes()));  // prints:  {hello:"world"}
 ```
 
-If the desired output is pretty text or binary, `ion.makeBinaryWriter()`
-or `ion.makePrettyWriter()` should be used instead of `ion.makeTextWriter()`.
-The result of `getBytes()` from a text, pretty, or binary writer can subsequently
+If Ion binary encoding is desired, use `ion.makeBinaryWriter()` instead of `ion.makeTextWriter()`.
+The result of `getBytes()` from a text or binary writer can subsequently
 be passed as the parameter to `makeReader()` in order to read the Ion data.
 </div>
 
@@ -486,8 +485,8 @@ class PrettyPrint
     {
         IIonReader reader = IonReaderBuilder.Build("{level1: {level2: {level3: \"foo\"}, x: 2}, y: [a,b,c]}");
 
-        TextWriter tw = new StringWriter();
-        IIonWriter writer = IonTextWriterBuilder.Build(tw, new IonTextOptions {PrettyPrint = true});
+        using TextWriter tw = new StringWriter();
+        using IIonWriter writer = IonTextWriterBuilder.Build(tw, new IonTextOptions {PrettyPrint = true});
         writer.WriteValues(reader);
         writer.Finish();
         Console.WriteLine(tw.ToString());
@@ -1203,24 +1202,22 @@ class CsvToIon
 {
     public static void Main(string[] args)
     {
-        TextWriter tw = new StringWriter();
-        IIonWriter writer = IonTextWriterBuilder.Build(tw);
+        using TextWriter tw = new StringWriter();
+        using IIonWriter writer = IonTextWriterBuilder.Build(tw);
 
-        using (var reader = new StreamReader("test.csv"))
+        using StreamReader reader = new StreamReader("test.csv");
+        reader.ReadLine();    // skip the header row
+        while (!reader.EndOfStream)
         {
-            reader.ReadLine();    // skip the header row
-            while (!reader.EndOfStream)
-            {
-                string[] values = reader.ReadLine().Split(",");
-                writer.StepIn(IonType.Struct);
-                writer.SetFieldName("id");
-                writer.WriteInt(long.Parse(values[0]));
-                writer.SetFieldName("type");
-                writer.WriteString(values[1]);
-                writer.SetFieldName("state");
-                writer.WriteBool(bool.Parse(values[2]));
-                writer.StepOut();
-            }
+            string[] values = reader.ReadLine().Split(",");
+            writer.StepIn(IonType.Struct);
+            writer.SetFieldName("id");
+            writer.WriteInt(long.Parse(values[0]));
+            writer.SetFieldName("type");
+            writer.WriteString(values[1]);
+            writer.SetFieldName("state");
+            writer.WriteBool(bool.Parse(values[2]));
+            writer.StepOut();
         }
         writer.Finish();
         Console.WriteLine(tw.ToString());


### PR DESCRIPTION
Additionally:
* updates the Java "readNumericTypes" example to align more closely with others
* positions note about local symbol tables below the CSV-to-Ion examples

I propose we merge these changes only after the initial release of ion-dotnet and include a link to its API documentation.

Resolves #102

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
