### PR TITLE
Updating C# example to use HasAnnotation

### DIFF
--- a/guides/cookbook.md
+++ b/guides/cookbook.md
@@ -1012,7 +1012,7 @@ class SparseReads
         IonType type;
         while ((type = reader.MoveNext()) != IonType.None)
         {
-            if (type == IonType.Struct && HasAnnotation(reader, "foo"))
+            if (type == IonType.Struct && reader.HasAnnotation("foo"))
             {
                 reader.StepIn();
                 while ((type = reader.MoveNext()) != IonType.None)
@@ -1026,21 +1026,7 @@ class SparseReads
                 reader.StepOut();
             }
         }
-
         Console.WriteLine("sum: " + sum);
-    }
-
-    static bool HasAnnotation(IIonReader reader, string annotation)
-    {
-        IEnumerable<SymbolToken> annotations = reader.GetTypeAnnotations();
-        foreach (SymbolToken token in annotations)
-        {
-            if (token.Text.Equals(annotation))
-            {
-                return true;
-            }
-        }
-        return false;
     }
 }
 ```


### PR DESCRIPTION
resolves https://github.com/amzn/ion-dotnet/issues/85

Updating the Sparse Reads example in the cookbook for C#. Removing the inline implementation to check if the annotation is present to use the new `bool HasAnnotation(string annotation)` implemented in IIonReader.