### PR TITLE
Adds JavaScript example of down-converting to JSON

### DIFF
--- a/guides/cookbook.md
+++ b/guides/cookbook.md
@@ -878,7 +878,14 @@ void downconvertToJson() throws IOException {
 </div>
 
 <div class="tabpane JavaScript" markdown="1">
-Not currently supported.
+Any `Value` object returned by `load()` may be converted by a JSON string by passing it to `JSON.stringify()`:
+
+```javascript
+let ion = require('ion-js');
+
+let value = ion.load('{data: annot::{foo: null.string, bar: (2 + 2)}, time: 1969-07-20T20:18Z}');
+console.log(JSON.stringify(value));
+```
 </div>
 
 <div class="tabpane Python" markdown="1">


### PR DESCRIPTION
Resolves #121 

Note that the resulting string is slightly different than that shown above it in the cookbook.

cookbook:
```json
{
  "data": {
    "foo": null,
    "bar": [
      2,
      "+",
      2
    ]
  },
  "time": "1969-07-20T20:18Z"
}
```

proposed ion-js example:
```
{"data":{"foo":null,"bar":[2,"+",2]},"time":"1969-07-20T20:18:00.000Z"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
