### PR TITLE
Add Go tab to the cookboook

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,6 +3,7 @@
     <p>
       <a href="https://github.com/amzn/ion-c">Ion C</a>
       | <a href="https://github.com/amzn/ion-dotnet">Ion .NET</a>
+      | <a href="https://github.com/amzn/ion-go">Ion Go</a>
       | <a href="https://github.com/amzn/ion-java">Ion Java</a>
       | <a href="https://github.com/amzn/ion-js">Ion JavaScript</a>
       | <a href="https://github.com/amzn/ion-python">Ion Python</a>

--- a/guides/cookbook.md
+++ b/guides/cookbook.md
@@ -238,7 +238,7 @@ import (
 
 func main() {
 	reader := ion.NewReaderString("{hello:\"world\"}")
-	if reader.Next() { 											 // position the reader at the first value
+	if reader.Next() {                                           // position the reader at the first value
 		currentType := reader.Type()                             // the first value in the reader is struct
 		fmt.Println("Current type is:\t" + currentType.String()) // Current type is:   struct
 		reader.StepIn()                                          // step into struct

--- a/guides/cookbook.md
+++ b/guides/cookbook.md
@@ -227,7 +227,7 @@ If Ion binary encoding is desired, use `IonBinaryWriterBuilder` (instead of `Ion
 <div class="tabpane Go" markdown="1">
 Implementations of the [`Reader`][22] and [`Writer`][23] interfaces are responsible for reading and writing Ion data in both text and binary forms.
 
-In order to make and use a text reader, we can use `NewReaderString()`. The following example demonstrates how to read Ion data from a string:
+In order to create and then use a text reader, we can use `NewReaderString()`. The following example demonstrates how to read Ion data from a string:
 ```Go
 package main
 

--- a/guides/cookbook.md
+++ b/guides/cookbook.md
@@ -258,7 +258,7 @@ func main() {
 ```
 If we have a binary Ion, `NewReaderBytes()` can be used in the same fashion.
 
-To write the the same struct as above, `{hello:"world"}`, we can use `NewTextWriter()` as shown below:
+To write the same struct as above, `{hello:"world"}`, we can use `NewTextWriter()` as shown below:
 ```Go
 package main
 
@@ -1209,7 +1209,7 @@ import (
 
 func main() {
 	int32Value := 2147483646
-	var int64Value int64 = 9223372036854775807
+	int64Value := 9223372036854775807
 	floatValue := 123.4
 	bigIntValue := new(big.Int).Neg(new(big.Int).SetUint64(18446744073709551615))
 	decimalValue := ion.MustParseDecimal("123.4d-2")
@@ -1242,7 +1242,7 @@ func main() {
 				if err != nil {
 					panic(err)
 				}
-				if int64Value != val {
+				if int64(int64Value) != val {
 					fmt.Println("Problem with Int64 value equivalency")
 				}
 			case ion.BigInt:

--- a/guides/cookbook.md
+++ b/guides/cookbook.md
@@ -1196,7 +1196,7 @@ A reader can have various types of numeric values:
   - Float
   - Decimal
 
-The following example illustrates how to read different numeric values in a reader:
+The following example illustrates how to read different numeric values:
 ```Go
 package main
 

--- a/guides/cookbook.md
+++ b/guides/cookbook.md
@@ -1614,6 +1614,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/amzn/ion-go/ion"
 )
 

--- a/guides/cookbook.md
+++ b/guides/cookbook.md
@@ -1923,7 +1923,7 @@ import (
 )
 
 func main() {
-	file, er := os.Open("c://values.cvs")
+	file, er := os.Open("test.csv")
 	if er != nil {
 		panic(er)
 	}

--- a/guides/cookbook.md
+++ b/guides/cookbook.md
@@ -227,7 +227,7 @@ If Ion binary encoding is desired, use `IonBinaryWriterBuilder` (instead of `Ion
 <div class="tabpane Go" markdown="1">
 Implementations of the [`Reader`][22] and [`Writer`][23] interfaces are responsible for reading and writing Ion data in both text and binary forms.
 
-In order to make and use a text reader, we can use `NewReaderString()`. The following example demonstrates how to read an Ion data from a string:
+In order to make and use a text reader, we can use `NewReaderString()`. The following example demonstrates how to read Ion data from a string:
 ```Go
 package main
 
@@ -239,9 +239,9 @@ import (
 func main() {
 	reader := ion.NewReaderString("{hello:\"world\"}")
 	if reader.Next() {                                           // position the reader at the first value
-		currentType := reader.Type()                             // the first value in the reader is struct
+		currentType := reader.Type()                             // the first value in the reader is a struct
 		fmt.Println("Current type is:\t" + currentType.String()) // Current type is:   struct
-		reader.StepIn()                                          // step into struct
+		reader.StepIn()                                          // step into the struct
 		reader.Next()                                            // position the reader at the first value in the struct
 		currentType = reader.Type()                              // the first value in the struct is of type string
 		fmt.Println("Current type, after stepping in the struct:\t" +
@@ -252,11 +252,11 @@ func main() {
 			panic("Reading string value failed.")
 		}
 		reader.StepOut()                    // step out of the struct
-		fmt.Println(*fieldName, " ", value) // hello   world
+		fmt.Println(*fieldName, " ", value) // hello world
 	}
 }
 ```
-Should we have a binary Ion, `NewReaderBytes()` can be used in the same fashion.
+If we have a binary Ion, `NewReaderBytes()` can be used in the same fashion.
 
 To write the the same struct as above, `{hello:"world"}`, we can use `NewTextWriter()` as shown below:
 ```Go
@@ -805,7 +805,7 @@ class PrettyPrint
 </div>
 
 <div class="tabpane Go" markdown="1">
-Ion data can be pretty-printed using `NewTextWriterOpts` and pass `TextWriterPretty` option to it:
+Ion data can be pretty-printed using `NewTextWriterOpts` and by passing the `TextWriterPretty` option to it:
 ```Go
 package main
 
@@ -2417,4 +2417,3 @@ openTab('Java');  // default tab
 [22]: https://github.com/amzn/ion-go/blob/master/ion/reader.go
 [23]: https://github.com/amzn/ion-go/blob/master/ion/writer.go
 [24]: https://pkg.go.dev/github.com/amzn/ion-go/ion
-

--- a/index.md
+++ b/index.md
@@ -24,7 +24,7 @@ challenges faced every day while engineering large-scale, service-oriented
 architectures. It has been addressing these challenges within Amazon for nearly
 a decade, and we believe others will benefit as well.
 
-**Available Languages:** [C][4] -- [C#][20] -- [Java][3] -- [JavaScript][6] -- [Python][5] <br>
+**Available Languages:** [C][4] -- [C#][20] -- [Go][21] -- [Java][3] -- [JavaScript][6] -- [Python][5] <br>
 **Related Projects:** [Ion Hash][19] -- [Ion Schema][17]<br>
 **Tools:** [Hive SerDe][18]<br>
 
@@ -162,3 +162,4 @@ To learn more, check out the [Docs][8] page, or see [Libs][12] for the officiall
 [18]: https://github.com/amzn/ion-hive-serde
 [19]: https://amzn.github.io/ion-hash
 [20]: https://github.com/amzn/ion-dotnet
+[21]: https://github.com/amzn/ion-go


### PR DESCRIPTION
As [ion-go v0.1.0-beta](https://github.com/amzn/ion-go/tags) is ready, this is to add Go examples and links in the cookbook.

I was not sure about the destination branch, so I followed what was done [for dot-net](https://github.com/amzn/ion-docs/pull/97).