### PR TITLE
Adds recent news and updates libs

### DIFF
--- a/_posts/2020-09-29-ion-go-1_0-released.md
+++ b/_posts/2020-09-29-ion-go-1_0-released.md
@@ -1,0 +1,12 @@
+---
+layout: news_item
+title: "Ion Go 1.0 Released"
+date: 2020-09-29
+categories: news ion-go
+---
+This first release for Go provides full support for the Ion type system and includes reader and writer APIs.
+
+The package is available via [GitHub](https://github.com/amzn/ion-go).
+
+| [Release Notes](https://github.com/amzn/ion-go/releases/tag/v1.0.0) | [Ion Go](https://github.com/amzn/ion-go) |
+

--- a/_posts/2020-09-30-ion-hash-go-1_0_0-released.md
+++ b/_posts/2020-09-30-ion-hash-go-1_0_0-released.md
@@ -1,0 +1,11 @@
+---
+layout: news_item
+title: "Ion Hash Go 1.0 Released"
+date: 2020-09-30
+categories: news ion-hash-go
+---
+This release provides full support for hashing all Ion values.
+
+The package is available via [GitHub](https://github.com/amzn/ion-hash-go).
+
+| [Release Notes](https://github.com/amzn/ion-hash-go/releases/tag/v1.0.0) | [Ion Go](https://github.com/amzn/ion-hash-go) |

--- a/_posts/2020-11-09-ion-java-1_8_0-released.md
+++ b/_posts/2020-11-09-ion-java-1_8_0-released.md
@@ -1,0 +1,13 @@
+---
+layout: news_item
+title: "Ion Java 1.8.0 Released"
+date: 2020-11-09
+categories: news ion-java
+---
+This release includes:
+* A bug fix in IonReaderBinaryRawX.readBytes ([#318](https://github.com/amzn/ion-java/issues/318)).
+* Avoiding repetitive reallocation of PooledBlockAllocatorProvider in _PrivateIon_HashTrampoline.
+
+
+| [Release Notes](https://github.com/amzn/ion-java/releases/tag/v1.8.0) | [Ion Java](https://github.com/amzn/ion-java) |
+

--- a/_posts/2020-11-23-ion-dotnet-1_1_0-released.md
+++ b/_posts/2020-11-23-ion-dotnet-1_1_0-released.md
@@ -1,0 +1,16 @@
+---
+layout: news_item
+title: "Ion .NET 1.1.0 Released"
+date: 2020-11-23
+categories: news ion-dotnet
+---
+This release includes:
+
+* Replacing the usage of decimal#TryParse(String, Decimal) with decimal#TryParse(String, NumberStyles, IFormatProvider, Decimal), allowing us to use InvariantCulture instead of the current thread's configured culture. ([#129](https://github.com/amzn/ion-dotnet/pull/129))
+* Adding a JSON text writer. ([#130](https://github.com/amzn/ion-dotnet/pull/130))
+* Moving to GitHub Actions for CI build. ([#124](https://github.com/amzn/ion-dotnet/pull/124))
+
+The Amazon.IonDotnet package is available via [NuGet](https://www.nuget.org/packages/Amazon.IonDotnet).
+
+| [Release Notes](https://github.com/amzn/ion-dotnet/releases/tag/v1.1.0) | [Ion .NET](https://github.com/amzn/ion-dotnet) |
+

--- a/libs.md
+++ b/libs.md
@@ -12,18 +12,18 @@ description: "The latest news about Amazon Ion and the Amazon Ion community."
 | Name | Latest Version | Repository | Documentation |
 |------|----------------|------|---------------|
 | ion-c | [1.0.3](https://github.com/amzn/ion-c/releases/latest) (December 11, 2019) | [Link](https://github.com/amzn/ion-c) | [Link](https://amzn.github.io/ion-c/) |
-| ion-dotnet | [1.0.0](https://github.com/amzn/ion-dotnet/releases/latest) (June 3, 2020) | [Link](https://github.com/amzn/ion-dotnet) | - |
-| ion-go | in development | [Link](https://github.com/amzn/ion-go) | - |
-| ion-java | [1.6.1](https://github.com/amzn/ion-java/releases/latest) (March 19, 2020) | [Link](https://github.com/amzn/ion-java) | [Link](https://www.javadoc.io/doc/com.amazon.ion/ion-java/) |
-| ion-js | [4.0.0](https://github.com/amzn/ion-js/releases/latest) (March 30, 2020) | [Link](https://github.com/amzn/ion-js) | [Link](https://amzn.github.io/ion-js/api/) |
-| ion-python | [0.5.0](https://github.com/amzn/ion-python/releases/latest) (October 17, 2019) | [Link](https://github.com/amzn/ion-python) | [Link](https://ion-python.readthedocs.io/en/latest/amazon.ion.html) |
+| ion-dotnet | [1.1.0](https://github.com/amzn/ion-dotnet/releases/latest) (November 24, 2020) | [Link](https://github.com/amzn/ion-dotnet) | - |
+| ion-go | [1.0.1](https://giithub.com/amzn/ion-go/releases/latest) (October 16, 2020) | [Link](https://github.com/amzn/ion-go) | - |
+| ion-java | [1.8.0](https://github.com/amzn/ion-java/releases/latest) (November 9, 2020) | [Link](https://github.com/amzn/ion-java) | [Link](https://www.javadoc.io/doc/com.amazon.ion/ion-java/) |
+| ion-js | [4.0.1](https://github.com/amzn/ion-js/releases/latest) (May 27, 2020) | [Link](https://github.com/amzn/ion-js) | [Link](https://amzn.github.io/ion-js/api/) |
+| ion-python | [0.6.0](https://github.com/amzn/ion-python/releases/latest) (April 26, 2020) | [Link](https://github.com/amzn/ion-python) | [Link](https://ion-python.readthedocs.io/en/latest/amazon.ion.html) |
 | ion-rust | in development | [Link](https://github.com/amzn/ion-rust) | - |
 
 ### Extensions
 
 | Name | Latest Version | Repository |
 |------|------|---------|
-| ion-java-path-extraction | [1.2.0](https://github.com/amzn/ion-java-path-extraction/releases/latest) (May 8, 2019) | [Link](https://github.com/amzn/ion-java-path-extraction) |
+| ion-java-path-extraction | [1.3.0](https://github.com/amzn/ion-java-path-extraction/releases/latest) (October 27, 2020) | [Link](https://github.com/amzn/ion-java-path-extraction) |
 
 ## Ion Team Supported Tools
 
@@ -39,4 +39,4 @@ description: "The latest news about Amazon Ion and the Amazon Ion community."
 
 | Name | Repository | Documentation |
 |------|------------|---------------|
-| Ion support in Jackson |  [Link](https://github.com/FasterXML/jackson-dataformats-binary/tree/master/ion) | [Link](http://fasterxml.github.io/jackson-dataformats-binary/javadoc/ion/2.9/) |
+| Ion support in Jackson |  [Link](https://github.com/FasterXML/jackson-dataformats-binary/tree/master/ion) | [Link](http://fasterxml.github.io/jackson-dataformats-binary/javadoc/ion/2.10/) |


### PR DESCRIPTION
Adds news for:
* ion-go 1.0
* ion-hash-go 1.0
* ion-java 1.8
* ion-dotnet 1.1.0

Updates lib versions for:
* ion-dotnet
* ion-go
* ion-java
* ion-js
* ion-python
* ion-java-path-extraction
* Ion support in Jackson (documentation version)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
