### PR TITLE
Make the L = 14 struct size case explicit

### DIFF
--- a/docs/binary.md
+++ b/docs/binary.md
@@ -580,12 +580,12 @@ _L_ is one. Thus:
     nested fields.
   * When _L_ is 1, the struct has at least one symbol/value pair, the _length_
     field exists, and the field name integers are sorted in increasing order.
+  * When _L_ is 14, the _length_ field exists, and no assertion is made about field
+    ordering.
   * When _L_ is 15, the value is `null.struct`, and there's no _length_ or
     nested fields.
-  * When _1 < L < 14_ then there is no _length_ field as _L_ is enough to represent
+  * Otherwise _1 < L < 14_ then there is no _length_ field as _L_ is enough to represent
     the struct size, and no assertion is made about field ordering.
-  * Otherwise _L_ is 14, the _length_ field exists, and no assertion is made about field
-    ordering.
 
 **Note:** Because VarUInts depend on end tags to indicate their lengths,
 finding the succeeding value requires parsing the field name prefix. However,

--- a/docs/binary.md
+++ b/docs/binary.md
@@ -584,7 +584,7 @@ _L_ is one. Thus:
     nested fields.
   * When _1 < L < 14_ then there is no _length_ field as _L_ is enough to represent
     the struct size, and no assertion is made about field ordering.
-  * Otherwise, the _length_ field exists, and no assertion is made about field
+  * Otherwise _L_ is 14, the _length_ field exists, and no assertion is made about field
     ordering.
 
 **Note:** Because VarUInts depend on end tags to indicate their lengths,

--- a/docs/binary.md
+++ b/docs/binary.md
@@ -584,8 +584,8 @@ _L_ is one. Thus:
     ordering.
   * When _L_ is 15, the value is `null.struct`, and there's no _length_ or
     nested fields.
-  * Otherwise _1 < L < 14_ then there is no _length_ field as _L_ is enough to represent
-    the struct size, and no assertion is made about field ordering.
+  * Otherwise, _1 < L < 14_  and there is no _length_ field as _L_ is enough to represent
+    the struct size. No assertion is made about field ordering.
 
 **Note:** Because VarUInts depend on end tags to indicate their lengths,
 finding the succeeding value requires parsing the field name prefix. However,


### PR DESCRIPTION
*Description of changes:* I think this phrasing of struct size semantics is a little more clear, opening this PR to see if anyone else agrees.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
