### PR TITLE
libs: Add Mir Ion

### DIFF
--- a/libs.md
+++ b/libs.md
@@ -40,4 +40,4 @@ description: "The latest news about Amazon Ion and the Amazon Ion community."
 | Name | Repository | Documentation |
 |------|------------|---------------|
 | Ion support in Jackson |  [Link](https://github.com/FasterXML/jackson-dataformats-binary/tree/master/ion) | [Link](http://fasterxml.github.io/jackson-dataformats-binary/javadoc/ion/2.12/) |
-| Mir Ion | [Link](https://github.com/libmir/mir-ion) | [Link](http://mir-ion.libmir.org/) |
+| Mir Ion (D language) | [Link](https://github.com/libmir/mir-ion) | [Link](http://mir-ion.libmir.org/) |

--- a/libs.md
+++ b/libs.md
@@ -40,3 +40,4 @@ description: "The latest news about Amazon Ion and the Amazon Ion community."
 | Name | Repository | Documentation |
 |------|------------|---------------|
 | Ion support in Jackson |  [Link](https://github.com/FasterXML/jackson-dataformats-binary/tree/master/ion) | [Link](http://fasterxml.github.io/jackson-dataformats-binary/javadoc/ion/2.12/) |
+| Mir Ion | [Link](https://github.com/libmir/mir-ion) | [Link](http://mir-ion.libmir.org/) |


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Hey, all. I'm one of the developers on Mir Ion -- an implementation of Ion written in the [D Language](https://dlang.org). I'm just reaching out to have our library included under the "community supported tools" section. ATM, we're not fully compatible with Text Ion (can serialize, but de-serializing is a WIP), but otherwise we're nearly 80% compatible with the Binary Ion test vectors released. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
