### PR TITLE
Clarify that `0.` is a decimal

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -170,10 +170,10 @@ null.float        // A null float value
 
 0E0               // Zero as float
 0D0               // Zero as decimal
-0.                //   ...the same value with different notation
+0.                //   ...the same decimal value with different notation
 -0e0              // Negative zero float   (distinct from positive zero)
 -0d0              // Negative zero decimal (distinct from positive zero)
--0.               //   ...the same value with different notation
+-0.               //   ...the same decimal value with different notation
 -0d-1             // Decimal maintains precision: -0. != -0.0
 
 123_456.789_012   // Decimal with underscores


### PR DESCRIPTION
There was a question as to whether "the same value with a different representation" meant a decimal or a float. This should be a nudge in the right direction.

*Issue #, if available:* None, this is in response to a user question. 

*Description of changes:* There was a question as to whether "the same value with a different representation" meant a decimal or a float. This should be a nudge in the right direction.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
