### PR TITLE
Slightly clarify where annotations are valid

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -673,9 +673,10 @@ value are separated by double-colons:
 ```
 {% raw %}
 int32::12                                // Suggests 32 bits as end-user type
+degrees::'celsius'::100                  // You can have multiple annotaions on a value
 'my.custom.type' :: { x : 12 , y : -1 }  // Gives a struct a user-defined type
 
-{ field: something::'another thing'::value }  // Field's name must precede annotations of its value
+{ field: some_annotation::value }        // Field's name must precede annotations of its value
 
 jpeg :: {{ ... }}                        // Indicates the blob contains jpeg data
 bool :: null.int                         // A very misleading annotation on the integer null

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -667,7 +667,8 @@ When multiple annotations are present, the Ion processor will maintain
 their order. Duplicate annotation symbols are allowed but discouraged.
 
 In the text format, type annotations are denoted by a non-null symbol
-token and double-colons preceding any content:
+token and double-colons preceding any value. Multiple annotations on the same
+value are separated by double-colons:
 
 ```
 {% raw %}


### PR DESCRIPTION
*Description of changes:*
Since "content" is not well-defined in the Ion spec, this clarifies that annotations can be applied to values. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
