### PR TITLE
A few tweaks to docs

### DIFF
--- a/docs/binary.md
+++ b/docs/binary.md
@@ -4,7 +4,7 @@ title: Ion Binary Encoding
 description: "An explanation of the Amazon Ion binary encoding."
 ---
 
-# [Docs][1]/ {{ page.title }}
+# [Docs][docs]/ {{ page.title }}
 
 This document covers the binary Ion format.
 
@@ -13,8 +13,8 @@ This document covers the binary Ion format.
 
 ## Value Streams
 
-In the binary format, a [value stream][2] always starts with a
-_binary version marker_ (BVM) that specifies the precise Ion version used to
+In the binary format, a [value stream][glossary-value-stream] always starts with
+a _binary version marker_ (BVM) that specifies the precise Ion version used to
 encode the data that follows:
 
 <pre class="textdiagram">
@@ -109,7 +109,7 @@ Int field  |   |      bits           |
 Ints are sequences of octets, interpreted as sign-and-magnitude big endian
 integers (with the sign on the highest-order bit of the first octet). This
 means that the representations of 123456 and -123456 should only differ in
-their sign bit. (See [Signed Number Representations][3]
+their sign bit. (See [Signed Number Representations][wiki-signed-num]
 for more info.)
 
 ### VarUInt and VarInt Fields
@@ -450,7 +450,7 @@ In the binary encoding, all Ion symbols are stored as integer _symbol IDs_
 whose text values are provided by a symbol table.  If _L_ is zero then the
 symbol ID is zero and the length and symbol ID fields are omitted.
 
-See [Ion Symbols][4] for more details about symbol representations
+See [Ion Symbols][symbols] for more details about symbol representations
 and symbol tables.
 
 
@@ -601,7 +601,7 @@ two bytes.
 
 Implementations should use symbol ID zero as the field name
 to emphasize the lack of meaning of the field name. For more general details
-about the semantics of symbol ID zero, refer to [Ion Symbols][4].
+about the semantics of symbol ID zero, refer to [Ion Symbols][symbols].
 
 For example, consider the following empty `struct` with three bytes of
 padding:
@@ -758,7 +758,7 @@ The type code 15 is illegal in Ion 1.0 data.
 </table>
 
 <!-- References -->
-[1]: {{ site.baseurl }}/docs.html
-[2]: glossary.html#value_stream
-[3]: http://en.wikipedia.org/wiki/Signed_number_representations
-[4]: symbols.html
+[docs]: {{ site.baseurl }}/docs.html
+[glossary-value-stream]: glossary.html#value_stream
+[wiki-signed-num]: http://en.wikipedia.org/wiki/Signed_number_representations
+[symbols]: symbols.html

--- a/docs/binary.md
+++ b/docs/binary.md
@@ -35,7 +35,7 @@ contain the actual data. These values are generally referred to as "top-level
 values".
 
 <pre class="textdiagram">
-              31                      0
+
              +-------------------------+
 value stream |  binary version marker  |
              +-------------------------+
@@ -83,7 +83,6 @@ UInt field |          bits           |
            +=========================+
            :          bits           :
            +=========================+
-            n+7                     n
 </pre>
 
 UInts are sequences of octets, interpreted as big-endian.
@@ -103,7 +102,6 @@ Int field  |   |      bits           |
            +=========================+
            :          bits           :
            +=========================+
-            n+7                     n
 </pre>
 
 Ints are sequences of octets, interpreted as sign-and-magnitude big endian
@@ -121,7 +119,7 @@ octet (and only the last octet) has its high-order bit set to terminate the
 field.
 
 <pre class="textdiagram">
-                7  6                   0       n+7 n+6                 n
+                7  6                   0        7                      0
               +===+=====================+     +---+---------------------+
 VarUInt field : 0 :         bits        :  …  | 1 |         bits        |
               +===+=====================+     +---+---------------------+
@@ -131,7 +129,7 @@ VarUInts are a sequence of octets. The high-order bit of the last octet is one,
 indicating the end of the sequence. All other high-order bits must be zero.
 
 <pre class="textdiagram">
-               7   6  5               0       n+7 n+6                 n
+               7   6  5               0        7                      0
              +===+                           +---+
 VarInt field : 0 :       payload          …  | 1 |       payload
              +===+                           +---+
@@ -206,12 +204,12 @@ follows:
     field.
 
 
-### 0: null
+### 0x0: null
 
 <pre class="textdiagram">
             7       4 3       0
            +---------+---------+
-Null value |    0    |    15   |
+Null value |   0x0   |    15   |
            +---------+---------+
 </pre>
 
@@ -223,7 +221,7 @@ valid _L_ value is 15, representing the only value of this type, `null.null`.
 <pre class="textdiagram">
          7       4 3       0
         +---------+---------+
-NOP Pad |    0    |    L    |
+NOP Pad |   0x0   |    L    |
         +---------+---------+======+
         :     length [VarUInt]     :
         +--------------------------+
@@ -258,12 +256,12 @@ NOP padding is valid anywhere a value can be encoded, except for within an
 [annotation](#annotations) wrapper. [NOP padding in `struct`](#nop-pad-struct)
 requires additional encoding considerations.
 
-### 1: bool
+### 0x1: bool
 
 <pre class="textdiagram">
             7       4 3       0
            +---------+---------+
-Bool value |    1    |   rep   |
+Bool value |   0x1   |   rep   |
            +---------+---------+
 </pre>
 
@@ -273,7 +271,7 @@ representation of 0 means false; a representation of 1 means true; and a
 representation of 15 means `null.bool`.
 
 
-### 2 and 3: int
+### 0x2 and 0x3: int
 
 Values of type `int` are stored using two type codes: 2 for positive values
 and 3 for negative values. Both codes use a UInt subfield to store the magnitude.
@@ -281,7 +279,7 @@ and 3 for negative values. Both codes use a UInt subfield to store the magnitude
 <pre class="textdiagram">
            7       4 3       0
           +---------+---------+
-Int value |  2 or 3 |    L    |
+Int value |0x2 / 0x3|    L    |
           +---------+---------+======+
           :     length [VarUInt]     :
           +==========================+
@@ -299,12 +297,12 @@ the magnitude is empty. Note that this implies there are two equivalent
 binary representations of null integer values.
 
 
-### 4: float
+### 0x4: float
 
 <pre class="textdiagram">
               7       4 3       0
             +---------+---------+
-Float value |    4    |    L    |
+Float value |   0x4   |    L    |
             +---------+---------+-----------+
             |   representation [IEEE-754]   |
             +-------------------------------+
@@ -330,12 +328,12 @@ There are two exceptions for the _L_ field:
 16-bit and 128-bit float values.
 
 
-### 5: decimal
+### 0x5: decimal
 
 <pre class="textdiagram">
                7       4 3       0
               +---------+---------+
-Decimal value |    5    |    L    |
+Decimal value |   0x5   |    L    |
               +---------+---------+======+
               :     length [VarUInt]     :
               +--------------------------+
@@ -356,13 +354,13 @@ If _L_ is 0 the value is `0.` (_aka_ `0d0`), and there are no length, exponent,
 or coefficient subfields.
 
 
-### 6: timestamp
+### 0x6: timestamp
 
 
 <pre class="textdiagram">
                  7       4 3       0
                 +---------+---------+
-Timestamp value |    6    |    L    |
+Timestamp value |   0x6   |    L    |
                 +---------+---------+========+
                 :      length [VarUInt]      :
                 +----------------------------+
@@ -433,12 +431,12 @@ components in the text encoding are in the local time! This means that
 transcoding requires a conversion between UTC and local time.
 
 
-### 7: symbol
+### 0x7: symbol
 
 <pre class="textdiagram">
               7       4 3       0
              +---------+---------+
-Symbol value |    7    |    L    |
+Symbol value |   0x7   |    L    |
              +---------+---------+======+
              :     length [VarUInt]     :
              +--------------------------+
@@ -454,12 +452,12 @@ See [Ion Symbols][symbols] for more details about symbol representations
 and symbol tables.
 
 
-### 8: string
+### 0x8: string
 
 <pre class="textdiagram">
               7       4 3       0
              +---------+---------+
-String value |    8    |    L    |
+String value |   0x8   |    L    |
              +---------+---------+======+
              :     length [VarUInt]     :
              +==========================+
@@ -472,12 +470,12 @@ UTF-8 octets. If _L_ is zero then the string is the empty string "" and the
 length and representation fields are omitted.
 
 
-### 9: clob
+### 0x9: clob
 
 <pre class="textdiagram">
             7       4 3       0
            +---------+---------+
-Clob value |    9    |    L    |
+Clob value |   0x9   |    L    |
            +---------+---------+======+
            :     length [VarUInt]     :
            +==========================+
@@ -492,12 +490,12 @@ application).
 Zero-length clobs are legal, so _L_ may be zero.
 
 
-### 10: blob
+### 0xA: blob
 
 <pre class="textdiagram">
             7       4 3       0
            +---------+---------+
-Blob value |   10    |    L    |
+Blob value |   0xA   |    L    |
            +---------+---------+======+
            :     length [VarUInt]     :
            +==========================+
@@ -511,12 +509,12 @@ application).
 Zero-length blobs are legal, so _L_ may be zero.
 
 
-### 11: list
+### 0xB: list
 
 <pre class="textdiagram">
             7       4 3       0
            +---------+---------+
-List value |   11    |    L    |
+List value |   0xB   |    L    |
            +---------+---------+======+
            :     length [VarUInt]     :
            +==========================+
@@ -535,12 +533,12 @@ Because values indicate their total lengths in octets, it is possible to locate
 the beginning of each successive value in constant time.
 
 
-### 12: sexp
+### 0xC: sexp
 
 <pre class="textdiagram">
             7       4 3       0
            +---------+---------+
-Sexp value |   12    |    L    |
+Sexp value |   0xC   |    L    |
            +---------+---------+======+
            :     length [VarUInt]     :
            +==========================+
@@ -553,7 +551,7 @@ Values of type `sexp` are encoded exactly as are `list` values, except with a
 different type code.
 
 
-### 13: struct
+### 0xD: struct
 
 Structs are encoded as sequences of symbol/value pairs. Since all symbols are
 encoded as positive integers, we can omit the typedesc on the field names and
@@ -562,7 +560,7 @@ just encode the integer value.
 <pre class="textdiagram">
               7       4 3       0
              +---------+---------+
-Struct value |   13    |    L    |
+Struct value |   0xD   |    L    |
              +---------+---------+======+
              :     length [VarUInt]     :
              +======================+===+==================+
@@ -644,7 +642,7 @@ codes. The annotations themselves are encoded as integer symbol ids.
 <pre class="textdiagram">
                     7       4 3       0
                    +---------+---------+
-Annotation wrapper |   14    |    L    |
+Annotation wrapper |   0xE   |    L    |
                    +---------+---------+======+
                    :     length [VarUInt]     :
                    +--------------------------+
@@ -702,7 +700,7 @@ The following table enumerates the illegal type descriptors in Ion 1.0 data.
 </thead>
 <tbody>
 <tr class="even">
-<td align="left">1</td>
+<td align="left">0x1</td>
 <td align="left">[2-14]</td>
 <td align="left">
 For <code>bool</code> values, <i>L</i> is used to encode the value, and may be
@@ -710,7 +708,7 @@ For <code>bool</code> values, <i>L</i> is used to encode the value, and may be
 </td>
 </tr>
 <tr class="odd">
-<td align="left">3</td>
+<td align="left">0x3</td>
 <td align="left">[0]</td>
 <td align="left">
 The <code>int</code> 0 is always stored with type code 2. Thus,
@@ -718,7 +716,7 @@ type code 3 with <i>L</i> equal to zero is illegal.
 </td>
 </tr>
 <tr class="even">
-<td align="left">4</td>
+<td align="left">0x4</td>
 <td align="left">[1-3],[5-7],[9-14]</td>
 <td align="left">
 For <code>float</code> values, only 32-bit and 64-bit IEEE-754 values are
@@ -727,7 +725,7 @@ represented with <i>L</i> equal to 0 and 15, respectively.
 </td>
 </tr>
 <tr class="odd">
-<td align="left">6</td>
+<td align="left">0x6</td>
 <td align="left">[0-1]</td>
 <td align="left">
 For <code>timestamp</code> values, a VarInt offset and VarUInt year are required.
@@ -735,7 +733,7 @@ Thus, type code 6 with <i>L</i> equal to zero or one is illegal.
 </td>
 </tr>
 <tr class="even">
-<td align="left">14</td>
+<td align="left">0xE</td>
 <td align="left">[0]*,[1-2],[15]</td>
 <td align="left">
 Annotation wrappers must have one <i>annot_length</i> field, at least one
@@ -748,10 +746,10 @@ errors when it is not followed by the rest of the BVM octet sequence.
 </td>
 </tr>
 <tr class="odd">
-<td align="left">15</td>
+<td align="left">0xF</td>
 <td align="left">[0-15]</td>
 <td align="left">
-The type code 15 is illegal in Ion 1.0 data.
+The type code 0xF is illegal in Ion 1.0 data.
 </td>
 </tr>
 </tbody>

--- a/docs/binary.md
+++ b/docs/binary.md
@@ -666,9 +666,7 @@ fields.
 
 It is illegal for an annotation to wrap another annotation atomically, _i.e._,
 _annotation(annotation(value))_. However, it is legal to have an annotation on
-a container that holds annotated values. Note that it is possible to enforce
-the illegality of _annotation(annotation(value))_ directly in a grammar, but we
-have not chosen to do that in this document.
+a container that holds annotated values.
 
 Furthermore, it is illegal for an annotation to wrap a [NOP Pad](#nop-pad)
 since this encoding is not an Ion value.  Thus, the following sequence is

--- a/docs/decimal.md
+++ b/docs/decimal.md
@@ -4,7 +4,7 @@ title: Decimals
 description: "Amazon Ion supports a decimal numeric type to allow accurate representation of base-10 floating point values such as currency amounts."
 ---
 
-# [Docs][1]/ {{ page.title }}
+# [Docs][docs]/ {{ page.title }}
 
 Amazon Ion supports a decimal numeric type to allow accurate representation
 of base-10 floating point values such as currency amounts. This
@@ -22,8 +22,8 @@ numbers are irrational in base-2.
 
 ### Data Model
 
-Ion decimals follow the [IBM Hursley Lab General Decimal Arithmetic Specification][2],
-which defines an [abstract decimal data model][3] represented by the following
+Ion decimals follow the [IBM Hursley Lab General Decimal Arithmetic Specification][decarith],
+which defines an [abstract decimal data model][damodel] represented by the following
 3-tuple.
 
     (<sign 0|1>, <coefficient: unsigned integer>, <exponent: integer>)
@@ -36,7 +36,7 @@ forms of positive zero, also are distinguished only by the *exponent*.
 
 ### Text Format
 
-The Hursley rules for describing a _finite value_ [converting from textual notation][3] *must* be followed. 
+The Hursley rules for describing a _finite value_ [converting from textual notation][damodel] *must* be followed. 
 The Hursley rules for describing a _special value_ are **not** followed--the rules for 
 
 * `infinity`  -- rule is **not** applicable for Ion Decimals.
@@ -127,7 +127,7 @@ However, the following are **not** equivalent to each other.
 ### Binary Format
 
 The encoding of Ion decimals, which follows the decimal data model
-described above, is specified in [the Ion Binary Encoding][5].
+described above, is specified in [the Ion Binary Encoding][binary].
 
 The following binary encodings of decimal values are all equivalent to `0d0`.
 
@@ -208,8 +208,8 @@ Explicit encoding of 42d(negative)0
 </pre>
 
 <!-- References -->
-[1]: {{ site.baseurl }}/docs.html
-[2]: http://speleotrove.com/decimal/decarith.html
-[3]: http://speleotrove.com/decimal/damodel.html
-[4]: http://speleotrove.com/decimal/daconvs.html
-[5]: binary.html
+[docs]: {{ site.baseurl }}/docs.html
+[decarith]: http://speleotrove.com/decimal/decarith.html
+[damodel]: http://speleotrove.com/decimal/damodel.html
+[daconvs]: http://speleotrove.com/decimal/daconvs.html
+[binary]: binary.html

--- a/docs/float.md
+++ b/docs/float.md
@@ -4,7 +4,7 @@ title: Floats
 description: "Amazon Ion supports IEEE-754 binary floating point values using the IEEE-754 32-bit (binary32) and 64-bit (binary64) encodings."
 ---
 
-# [Docs][1]/ {{ page.title }}
+# [Docs][docs]/ {{ page.title }}
 Amazon Ion supports IEEE-754 binary floating point values using the IEEE-754
 32-bit (`binary32`) and 64-bit (`binary64`) encodings.
 In the data model, all floating point values are treated as though they are
@@ -35,12 +35,12 @@ more precision than can be stored in `binary64`, the exact `binary64`
 value is determined by using the IEEE-754 *round-to-nearest* mode with
 a *round-half-to-even* as the tie-break.  This mode/tie-break is the
 common default used in most programming environments and is discussed in detail
-in ["Correctly Rounded Binary-Decimal and Decimal-Binary Conversions"][2].
-This conversion algorithm is illustrated in a straightforward way in [Clinger's Algorithm][3].
+in ["Correctly Rounded Binary-Decimal and Decimal-Binary Conversions"][rounding].
+This conversion algorithm is illustrated in a straightforward way in [Clinger's Algorithm][clinger].
 
 When encoding a `binary32` or `binary64` value in text notation, an
 implementation MAY want to consider the approach described in
-["Printing Floating-Point Numbers Quickly and Accurately"][4].
+["Printing Floating-Point Numbers Quickly and Accurately"][printing-fp].
 
 ### Special Values
 The IEEE-754 binary floating point encoding supports special *non-number*
@@ -107,7 +107,7 @@ the following text forms all map to the same `binary64` value:
 ```
 
 <!-- References -->
-[1]: {{ site.baseurl }}/docs.html
-[2]: http://ampl.com/REFS/rounding.pdf
-[3]: http://www.cesura17.net/~will/professional/research/papers/howtoread.pdf
-[4]: http://www.cs.indiana.edu/~dyb/pubs/FP-Printing-PLDI96.pdf
+[docs]: {{ site.baseurl }}/docs.html
+[rounding]: http://ampl.com/REFS/rounding.pdf
+[clinger]: http://www.cesura17.net/~will/professional/research/papers/howtoread.pdf
+[printing-fp]: http://www.cs.indiana.edu/~dyb/pubs/FP-Printing-PLDI96.pdf

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -4,10 +4,10 @@ title: Glossary
 description: "The following terms have particular definitions as it relates to their usage within the Amazon Ion Specification documents."
 ---
 
-# [Docs][1]/ {{ page.title }}
+# [Docs][docs]/ {{ page.title }}
 
 The following terms have particular definitions as it relates to their usage
-within the [Amazon Ion Specification][2] documents.
+within the [Amazon Ion Specification][spec] documents.
 
 ## Symbol Token
 > A symbol token is a piece of text mapped to a integer symbol ID by a symbol table. In the binary format a symbol token is always encoded using the integer, not the text.
@@ -21,5 +21,5 @@ within the [Amazon Ion Specification][2] documents.
 > A (potentially unbounded) sequence of Ion values in either text or binary.
 
 <!-- References -->
-[1]: {{ site.baseurl }}/docs.html
-[2]: spec.html
+[docs]: {{ site.baseurl }}/docs.html
+[spec]: spec.html

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4,7 +4,7 @@ title: Specification
 description: "The Amazon Ion specification has three parts. A set of data types. A textual notation for values of those types. A binary notation for values of those types."
 ---
 
-# [Docs][1]/ {{ page.title }}
+# [Docs][docs]/ {{ page.title }}
 
 The Amazon Ion specification has three parts:
 
@@ -21,13 +21,13 @@ between the formats with almost complete fidelity. ("Almost" because
 converting from text to binary does not preserve whitespace and
 comments.)
 
-The Ion [text encoding][2] is intended to be easy to read and
+The Ion [text encoding][text] is intended to be easy to read and
 write. It may be more suitable for streaming applications since sequences
 don't need to be length-prefixed. Whitespace is insignificant and is only
 required where necessary to separate tokens. C-style comments are treated
 as whitespace, and are not part of the binary encoding.
 
-The [binary encoding][3] is
+The [binary encoding][binary] is
 much more compact and efficient. An important feature is that parts of
 the whole can be accessed without "preparation", meaning you don't have
 to load it into another form before accessing the values.
@@ -196,7 +196,7 @@ is preserved through round-trips. Because most decimal values cannot be
 represented exactly in binary floating-point, `float` values may change
 "appearance" and precision when reading or writing Ion text.
 
-See also [Ion Float][4] and [Ion Decimals][5] for more notes.
+See also [Ion Float][float] and [Ion Decimals][decimal] for more notes.
 
 ### Timestamps {#timestamp}
 
@@ -204,7 +204,7 @@ Timestamps represent a specific moment in time, always include a local
 offset, and are capable of arbitrary precision.
 
 In the text format, timestamps follow the [W3C note on date and time
-formats][6], but they must end with the
+formats][w3-datetime], but they must end with the
 literal "T" if not at least whole-day precision. Fractional seconds are
 allowed, with at least one digit of precision and an unlimited maximum.
 Local-time offsets may be represented as either hour:minute offsets from
@@ -212,13 +212,13 @@ UTC, or as the literal "Z" to denote a local time of UTC. They are
 required on timestamps with time and are not allowed on date values.
 
 Ion follows the "Unknown Local Offset Convention" of
-[RFC3339][7]:
+[RFC3339][rfc3339]:
 
 > If the time in UTC is known, but the offset to local time is unknown,
 > this can be represented with an offset of "-00:00". This differs
 > semantically from an offset of "Z" or "+00:00", which imply that UTC
 > is the preferred reference point for the specified time.
-> [RFC2822][8] describes a similar
+> [RFC2822][rfc2822] describes a similar
 > convention for email.
 
 Values that are precise only to the year, month, or date are assumed to
@@ -466,7 +466,7 @@ Note that the data model does not distinguish between identifiers,
 operators, or other symbols, and that -- as always -- the binary format
 does not retain whitespace.
 
-See [Ion Symbols][9] for more details about symbol
+See [Ion Symbols][symbols] for more details about symbol
 representations and symbol tables.
 
 ### Blobs {#blob}
@@ -476,14 +476,14 @@ treats such data as a single (though often very large) value. It does no
 processing of such data other than passing it through intact.
 
 In the text format, `blob` values are denoted as
-[RFC 4648][10]-compliant
-[Base64][11] text within two
+[RFC 4648][rfc4648]-compliant
+[Base64][wiki-b64] text within two
 pairs of curly braces.
 
 When parsing `blob` text, an error must be raised if the data:
 
   * Contains characters outside
-    of the [Base64 character set][12].
+    of the [Base64 character set][rfc4648-section-4].
   * Contains a padding character (`=`) anywhere other than at the end.
   * Is terminated by an incorrect number of padding characters.
 
@@ -531,7 +531,7 @@ unscathed while remaining generally readable (at least for western
 language text). Like `blob`s, `clob`s disallow comments everywhere
 within the value.
 
-[Strings and Clobs][13] gives details on the
+[Strings and Clobs][stringclob] gives details on the
 subtle, but profound, differences between Ion strings and clobs.
 
 ```
@@ -625,7 +625,7 @@ null.list         // A null list value
 
 ### S-Expressions {#sexp}
 
-An S-expression (or [symbolic expression][14])
+An S-expression (or [symbolic expression][wiki-s-exp])
 is much like a list in that it's an ordered collection
 of values. However, the notation aligns with Lisp syntax to connote use
 of application semantics like function calls or programming-language
@@ -695,17 +695,17 @@ symbol token is an *annotation* on the value, and the second is the
 *content* of the value.
 
 <!-- References -->
-[1]: {{ site.baseurl }}/docs.html
-[2]: text.html
-[3]: binary.html
-[4]: float.html
-[5]: decimal.html
-[6]: http://www.w3.org/TR/NOTE-datetime
-[7]: http://www.ietf.org/rfc/rfc3339.txt
-[8]: http://www.ietf.org/rfc/rfc2822.txt
-[9]: symbols.html
-[10]: https://tools.ietf.org/html/rfc4648
-[11]: http://en.wikipedia.org/wiki/Base64
-[12]: https://tools.ietf.org/html/rfc4648#section-4
-[13]: stringclob.html
-[14]: https://en.wikipedia.org/wiki/S-expression
+[docs]: {{ site.baseurl }}/docs.html
+[text]: text.html
+[binary]: binary.html
+[float]: float.html
+[decimal]: decimal.html
+[symbols]: symbols.html
+[stringclob]: stringclob.html
+[w3-datetime]: http://www.w3.org/TR/NOTE-datetime
+[rfc3339]: http://www.ietf.org/rfc/rfc3339.txt
+[rfc2822]: http://www.ietf.org/rfc/rfc2822.txt
+[rfc4648]: https://tools.ietf.org/html/rfc4648
+[rfc4648-section-4]: https://tools.ietf.org/html/rfc4648#section-4
+[wiki-b64]: http://en.wikipedia.org/wiki/Base64
+[wiki-s-exp]: https://en.wikipedia.org/wiki/S-expression

--- a/docs/stringclob.md
+++ b/docs/stringclob.md
@@ -4,14 +4,14 @@ title: Strings and Clobs
 description: "This document clarifies the semantics of the Amazon Ion string and clob data types with respect to escapes and the Unicode standard."
 ---
 
-# [Docs][1]/ {{ page.title }}
+# [Docs][docs]/ {{ page.title }}
 
 This document clarifies the semantics of the Amazon Ion
 `string` and `clob` data types with respect to
-escapes and the [Unicode][2] standard.
+escapes and the [Unicode][unicode] standard.
 
 As of the date of this writing, the Unicode Standard is on [version
-10.0][3]. This specification is to that standard.
+10.0][unicode-10]. This specification is to that standard.
 
 ## Unicode Primer
 
@@ -26,7 +26,7 @@ Traditionally, from a programmer's perspective, a code point can be
 thought of as a *character*, but there is sometimes a subtle
 distinction. For example, in Java, the `char` type is an unsigned,
 16-bit integer, which is normally used to hold UTF-16 *code units* (_e.g._
-[`java.lang.CharSequence`][4]).
+[`java.lang.CharSequence`][java-charsequence]).
 For the Unicode code point, **Mathematical Bold Capital "A"** (code point
 U+0001D400), this encoded in a UTF-16 string as two units: 0xD835 followed by
 0xDC00. So in this case, Java's UTF-16 representation actually utilizes two
@@ -37,7 +37,7 @@ referring to Unicode code points. The reasoning for this is partly
 stated above, but also has to do with the overloaded nature of the term
 (_e.g._ a user character or *grapheme*). For more details, consult section
 [3.4 of the Unicode
-Standard][5].
+Standard][unicode-10-ch3].
 
 Another interesting aspect of the UCS, is a block of code points that is
 reserved exclusively for use in the UTF-16 encoding (_i.e._ *surrogate*
@@ -46,7 +46,7 @@ allowed to represent the code points in the inclusive range U+D800 to
 U+DFFF. In the UTF-16 case, these code points are only allowed to be
 used in the encoding to specify characters in the U+00010000 to
 U+0010FFFF range. Refer to sections [3.8 and 3.9 of the Unicode
-Standard][5] for
+Standard][unicode-10-ch3] for
 details.
 
 ## Ion String
@@ -58,7 +58,7 @@ Ion binary and text formats.
 
 ### Text Format
 
-See the [grammar][6] for a formal definition of the
+See the [grammar][text-grammar] for a formal definition of the
 Ion Text encoding for the `string` type.
 
 Multiple Ion long `string` literals that are adjacent to each other by
@@ -249,7 +249,7 @@ octets and `string` is a sequence of Unicode code points.
 
 ### Text Format
 
-See the [grammar][6] for a formal definition of the
+See the [grammar][text-grammar] for a formal definition of the
 Ion Text encoding for the `clob` type.
 
 Similar to `string`, adjoining long string literals within an Ion `clob`
@@ -384,19 +384,18 @@ This is represented directly as the octet values in the `clob` value.
 
 ## References
 
-* [The Unicode Home Page][7]
-* [Unicode Encoding FAQ][8]
-* [Wikipedia UTF-16 Article][9]
-* [Wikipedia UTF-8 Article][10]
+* [The Unicode Home Page][unicode]
+* [Unicode Encoding FAQ][unicode-bom]
+* [Wikipedia UTF-8 Article][wiki-utf-8]
+* [Wikipedia UTF-16 Article][wiki-utf-16]
 
 <!-- references -->
-[1]: {{ site.baseurl }}/docs.html
-[2]: http://www.unicode.org/
-[3]: http://www.unicode.org/versions/Unicode10.0.0/
-[4]: https://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html
-[5]: http://www.unicode.org/versions/Unicode10.0.0/ch03.pdf
-[6]: text.html#grammar
-[7]: http://unicode.org
-[8]: http://www.unicode.org/faq/utf_bom.html
-[9]: http://en.wikipedia.org/wiki/UTF-16
-[10]: http://en.wikipedia.org/wiki/UTF-8
+[docs]: {{ site.baseurl }}/docs.html
+[text-grammar]: text.html#grammar
+[unicode]: http://unicode.org
+[unicode-bom]: http://www.unicode.org/faq/utf_bom.html
+[unicode-10]: http://www.unicode.org/versions/Unicode10.0.0/
+[unicode-10-ch3]: http://www.unicode.org/versions/Unicode10.0.0/ch03.pdf
+[java-charsequence]: https://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html
+[wiki-utf-8]: http://en.wikipedia.org/wiki/UTF-8
+[wiki-utf-16]: http://en.wikipedia.org/wiki/UTF-16

--- a/docs/symbols.md
+++ b/docs/symbols.md
@@ -4,7 +4,7 @@ title: Symbols
 description: "Amazon Ion symbols are critical to the notation's performance and space-efficiency. This page defines the various concepts and data structures related to symbol management."
 ---
 
-# [Docs][1]/ {{ page.title }}
+# [Docs][docs]/ {{ page.title }}
 
 Amazon Ion symbols are critical to the notation's performance and
 space-efficiency. This page defines the various concepts and data
@@ -622,4 +622,4 @@ annotations:
     }
 
 <!-- references -->
-[1]: {{ site.baseurl }}/docs.html
+[docs]: {{ site.baseurl }}/docs.html

--- a/docs/text.md
+++ b/docs/text.md
@@ -4,17 +4,17 @@ title: Ion Text Encoding
 description: "An explanation of the Amazon Ion text encoding."
 ---
 
-# [Docs][1]/ {{ page.title }}
+# [Docs][docs]/ {{ page.title }}
 
-A [value stream][2] in the text encoding must be a
+A [value stream][glossary-value-stream] in the text encoding must be a
 valid sequence of Unicode code points in any of the three encoding forms
 (i.e. UTF-8, UTF-16, or UTF-32).
 
 ## ANTLR Grammar {#grammar}
 
-View the [Ion Text ANTLR v4 Grammar][3].
+View the [Ion Text ANTLR v4 Grammar][ion-text-grammar].
 
 <!-- references -->
-[1]: {{ site.baseurl }}/docs.html
-[2]: glossary.html#value_stream
-[3]: {{ site.baseurl }}/grammar/IonText.g4.txt
+[docs]: {{ site.baseurl }}/docs.html
+[glossary-value-stream]: glossary.html#value_stream
+[ion-text-grammar]: {{ site.baseurl }}/grammar/IonText.g4.txt


### PR DESCRIPTION
*Description of changes:*
###Use hexadecimal numbers for type codes
We use hex code to represent binary encoding in our examples, and so do binary viewing and editing tools.  Labeling type codes with the hexadecimal numbers fits better. This commit also removes bit numbering in the binary examples, except for signaling the high and low bits of individual bytes. 

###Adopt reference-style links
This makes doc maintenance and citation easier. 

* Remove an aside about annotation(annotation(value)) restriction being possible in grammar. As the aside says, we didn't do that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
