### PR TITLE
Migrates CI build from Travis to Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,24 @@
+name: build
+
+on:
+  push:
+    branches: [ gh-pages ]
+  pull_request:
+    branches: [ gh-pages ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [11]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Use java ${{ matrix.java }}
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: ${{ matrix.java }}
+      - run: mvn verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: java
-sudo: false
-jdk:
-- openjdk11
-script: mvn verify
-


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

Migrates CI build from Travis to Github Actions.

~~I'll be honest, I have no idea why we are running `mvn verify` on this repo, but we are so I've migrated it to GH Actions.~~ Looks like we have a few tests in this repo, and that's why we're running `mvn verify`.

You can see it working on my fork of ion-docs [here](https://github.com/popematt/ion-docs/actions/runs/1309874170).

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
