### PR TITLE
Added ion-go doc link

### DIFF
--- a/libs.md
+++ b/libs.md
@@ -13,7 +13,7 @@ description: "The latest news about Amazon Ion and the Amazon Ion community."
 |------|----------------|------|---------------|
 | ion-c | [1.4.0](https://github.com/amzn/ion-c/releases/latest) (February 9, 2021) | [Link](https://github.com/amzn/ion-c) | [Link](https://amzn.github.io/ion-c/) |
 | ion-dotnet | [1.1.0](https://github.com/amzn/ion-dotnet/releases/latest) (November 24, 2020) | [Link](https://github.com/amzn/ion-dotnet) | - |
-| ion-go | [1.1.0](https://github.com/amzn/ion-go/releases/latest) (December 8, 2020) | [Link](https://github.com/amzn/ion-go) | [Link](https://pkg.go.dev/github.com/amzn/ion-go@/ion) |
+| ion-go | [1.1.0](https://github.com/amzn/ion-go/releases/latest) (December 8, 2020) | [Link](https://github.com/amzn/ion-go) | [Link](https://pkg.go.dev/github.com/amzn/ion-go/ion) |
 | ion-java | [1.8.1](https://github.com/amzn/ion-java/releases/latest) (April 7, 2021) | [Link](https://github.com/amzn/ion-java) | [Link](https://www.javadoc.io/doc/com.amazon.ion/ion-java/) |
 | ion-js | [4.2.1](https://github.com/amzn/ion-js/releases/latest) (May 6, 2021) | [Link](https://github.com/amzn/ion-js) | [Link](https://amzn.github.io/ion-js/api/) |
 | ion-python | [0.7.0](https://github.com/amzn/ion-python/releases/latest) (December 2, 2020) | [Link](https://github.com/amzn/ion-python) | [Link](https://ion-python.readthedocs.io/en/latest/amazon.ion.html) |

--- a/libs.md
+++ b/libs.md
@@ -13,7 +13,7 @@ description: "The latest news about Amazon Ion and the Amazon Ion community."
 |------|----------------|------|---------------|
 | ion-c | [1.4.0](https://github.com/amzn/ion-c/releases/latest) (February 9, 2021) | [Link](https://github.com/amzn/ion-c) | [Link](https://amzn.github.io/ion-c/) |
 | ion-dotnet | [1.1.0](https://github.com/amzn/ion-dotnet/releases/latest) (November 24, 2020) | [Link](https://github.com/amzn/ion-dotnet) | - |
-| ion-go | [1.1.0](https://github.com/amzn/ion-go/releases/latest) (December 8, 2020) | [Link](https://github.com/amzn/ion-go) | - |
+| ion-go | [1.1.0](https://github.com/amzn/ion-go/releases/latest) (December 8, 2020) | [Link](https://github.com/amzn/ion-go) | [Link](https://pkg.go.dev/github.com/amzn/ion-go@/ion) |
 | ion-java | [1.8.1](https://github.com/amzn/ion-java/releases/latest) (April 7, 2021) | [Link](https://github.com/amzn/ion-java) | [Link](https://www.javadoc.io/doc/com.amazon.ion/ion-java/) |
 | ion-js | [4.2.1](https://github.com/amzn/ion-js/releases/latest) (May 6, 2021) | [Link](https://github.com/amzn/ion-js) | [Link](https://amzn.github.io/ion-js/api/) |
 | ion-python | [0.7.0](https://github.com/amzn/ion-python/releases/latest) (December 2, 2020) | [Link](https://github.com/amzn/ion-python) | [Link](https://ion-python.readthedocs.io/en/latest/amazon.ion.html) |


### PR DESCRIPTION
## Description

Added https://pkg.go.dev doc link for ion-go

## Why is this needed

Easy link for go developers

Fixes: #

N/A

## How Has This Been Tested?

N/A

## How are existing users impacted? What migration steps/scripts do we need?

N/A

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [x] provided instructions on how to upgrade
