### PR TITLE
Adds automated updates to the "Libraries" page

### DIFF
--- a/_data/libraries.json
+++ b/_data/libraries.json
@@ -1,0 +1,63 @@
+[
+  {
+    "name": "ion-c",
+    "category": "core",
+    "latest_release_version": "1.0.6",
+    "latest_release_date": "2022-03-28",
+    "documentation": "https://amzn.github.io/ion-c/"
+  },
+  {
+    "name": "ion-dotnet",
+    "category": "core",
+    "latest_release_version": "1.2.2",
+    "latest_release_date": "2022-02-08"
+  },
+  {
+    "name": "ion-java",
+    "category": "core",
+    "latest_release_version": "1.9.3",
+    "latest_release_date": "2022-03-23",
+    "documentation": "https://www.javadoc.io/doc/com.amazon.ion/ion-java/"
+  },
+  {
+    "name": "ion-js",
+    "category": "core",
+    "latest_release_version": "4.2.2",
+    "latest_release_date": "2022-03-17",
+    "documentation": "https://amzn.github.io/ion-js/api/"
+  },
+  {
+    "name": "ion-rust",
+    "category": "core"
+  },
+  {
+    "name": "ion-python",
+    "category": "core",
+    "latest_release_version": "0.9.1",
+    "latest_release_date": "2022-02-02",
+    "documentation": "https://ion-python.readthedocs.io/en/latest/amazon.ion.html"
+  },
+  {
+    "name": "ion-go",
+    "category": "core",
+    "latest_release_version": "1.1.3",
+    "latest_release_date": "2021-07-09",
+    "documentation": "https://pkg.go.dev/github.com/amzn/ion-go/ion"
+  },
+  {
+    "name": "ion-java-path-extraction",
+    "category": "extension",
+    "latest_release_version": "1.3.1",
+    "latest_release_date": "2021-07-09"
+  },
+  {
+    "name": "ion-element-kotlin",
+    "category": "extension"
+  },
+  {
+    "name": "ion-hive-serde",
+    "category": "extension",
+    "latest_release_version": "1.0.0",
+    "latest_release_date": "2022-03-15"
+  }
+]

--- a/_includes/library_table.md
+++ b/_includes/library_table.md
@@ -1,0 +1,24 @@
+| Name | Latest Version | Repository | Documentation |
+|------|----------------|------------|---------------|
+{% assign libraries = site.data.libraries | where: "category", library_type | sort: "name"  -%}
+{%- for row in libraries -%}
+  {%- assign name = row["name"] -%}
+  {%- capture release -%}
+    {%- if row["latest_release_version"] -%}
+      [{{ row["latest_release_version"] }}](https://github.com/amzn/{{ name }}/releases/latest) ({{ row["latest_release_date"] | date: "%B %d, %Y" }})
+    {%- else -%}
+      in development
+    {%- endif -%}
+  {%- endcapture -%}
+  {%- capture documentation -%}
+    {%- if row["documentation"] -%}
+      [Link]({{ row["documentation"] }})
+    {%- else -%}
+      -
+    {%- endif -%}
+  {%- endcapture -%}
+  {%- capture repository -%}
+    [Link](https://github.com/amzn/{{ name }})
+  {%- endcapture -%}
+  | {{ name }} | {{ release }} | {{ repository }} | {{ documentation }}
+{% endfor %}

--- a/libs.md
+++ b/libs.md
@@ -7,25 +7,18 @@ description: "The latest news about Amazon Ion and the Amazon Ion community."
 
 ## Ion Team Supported Libraries
 
+
 ### Core Parsers
 
-| Name | Latest Version | Repository | Documentation |
-|------|----------------|------|---------------|
-| ion-c | [1.4.0](https://github.com/amzn/ion-c/releases/latest) (February 9, 2021) | [Link](https://github.com/amzn/ion-c) | [Link](https://amzn.github.io/ion-c/) |
-| ion-dotnet | [1.1.0](https://github.com/amzn/ion-dotnet/releases/latest) (November 24, 2020) | [Link](https://github.com/amzn/ion-dotnet) | - |
-| ion-go | [1.1.0](https://github.com/amzn/ion-go/releases/latest) (December 8, 2020) | [Link](https://github.com/amzn/ion-go) | [Link](https://pkg.go.dev/github.com/amzn/ion-go/ion) |
-| ion-java | [1.8.1](https://github.com/amzn/ion-java/releases/latest) (April 7, 2021) | [Link](https://github.com/amzn/ion-java) | [Link](https://www.javadoc.io/doc/com.amazon.ion/ion-java/) |
-| ion-js | [4.2.1](https://github.com/amzn/ion-js/releases/latest) (May 6, 2021) | [Link](https://github.com/amzn/ion-js) | [Link](https://amzn.github.io/ion-js/api/) |
-| ion-python | [0.7.0](https://github.com/amzn/ion-python/releases/latest) (December 2, 2020) | [Link](https://github.com/amzn/ion-python) | [Link](https://ion-python.readthedocs.io/en/latest/amazon.ion.html) |
-| ion-rust | in development | [Link](https://github.com/amzn/ion-rust) | - |
+{% assign library_type = "core" %}
+{% include library_table.md %}
 
 ### Extensions
 
-| Name | Latest Version | Repository |
-|------|------|---------|
-| ion-java-path-extraction | [1.3.1](https://github.com/amzn/ion-java-path-extraction/releases/latest) (December 3, 2020) | [Link](https://github.com/amzn/ion-java-path-extraction) |
+{% assign library_type = "extension" %}
+{% include library_table.md %}
 
-## Ion Team Supported Tools
+### Developer Tools
 
 | Name | Repository | Release |
 |------|------|---------|
@@ -33,11 +26,11 @@ description: "The latest news about Amazon Ion and the Amazon Ion community."
 | ion-intellij-plugin | [Link](https://github.com/amzn/ion-intellij-plugin) | [Link](https://plugins.jetbrains.com/plugin/8409-amazon-ion-intellij-idea-plugin) |
 | ion-test-driver | [Link](https://github.com/amzn/ion-test-driver) | - |
 | ion-tests | [Link](https://github.com/amzn/ion-tests) | - |
-| ion-hive-serde | [Link](https://github.com/amzn/ion-hive-serde) | - |
 
-## Community Supported Tools
+## Community Supported Libraries
 
 | Name | Repository | Documentation |
 |------|------------|---------------|
 | Ion support in Jackson |  [Link](https://github.com/FasterXML/jackson-dataformats-binary/tree/master/ion) | [Link](http://fasterxml.github.io/jackson-dataformats-binary/javadoc/ion/2.12/) |
 | Mir Ion (D language) | [Link](https://github.com/libmir/mir-ion) | [Link](http://mir-ion.libmir.org/) |
+


### PR DESCRIPTION
#### Issue #, if available:

N/A

#### Description of changes:

Automates the "Latest Version" details on the Libraries page of the ion-docs Github pages website. Now the latest version will be updated whenever the GHA workflow creates a news post about a new release.

#### Testing
I ran the release workflow in my fork, and copied the results to a new branch before creating this PR. You can verify that it works by checking out [this commit](https://github.com/popematt/ion-docs/commit/a6642bfa37ddf51dd438a8d14b1cf9fea1d07f05).

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
