### PR TITLE
Adds news and libs entry for ext-ion.

### DIFF
--- a/_posts/2022-08-16-community-supported-php-library-added.md
+++ b/_posts/2022-08-16-community-supported-php-library-added.md
@@ -1,0 +1,12 @@
+---
+layout: news_item
+title: "Ext Ion, A Community Supported PHP Library"
+date: 2022-08-16
+categories: news ion-php
+---
+
+Ext Ion, [link](https://github.com/awesomized/ext-ion), is a PHP library for Ion from Awesomized, the developers behind SmugMug. The library wraps ion-c and is available for installation on PECL with `pecl install ion`. 
+
+The library is listed on the [libraries page](https://amzn.github.io/ion-docs/libs.html) under Community Supported Libraries.
+
+| [Ext Ion](https://github.com/awesomized/ext-ion) | [Community Supported Libraries](https://amzn.github.io/ion-docs/libs.html#community-supported-libraries) |

--- a/libs.md
+++ b/libs.md
@@ -33,4 +33,5 @@ description: "The latest news about Amazon Ion and the Amazon Ion community."
 |------|------------|---------------|
 | Ion support in Jackson |  [Link](https://github.com/FasterXML/jackson-dataformats-binary/tree/master/ion) | [Link](http://fasterxml.github.io/jackson-dataformats-binary/javadoc/ion/2.12/) |
 | Mir Ion (D language) | [Link](https://github.com/libmir/mir-ion) | [Link](http://mir-ion.libmir.org/) |
+| Ext Ion (PHP language) | [Link](https://github.com/awesomized/ext-ion) | - |
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Adds ext-ion, a new community supported Ion library for PHP, to the libraries page and includes a news item about the new library.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
