### PR TITLE
Adds news post for Ion CLI Hombrew tap

### DIFF
--- a/_posts/2022-08-24-ion-cli-homebrew.md
+++ b/_posts/2022-08-24-ion-cli-homebrew.md
@@ -1,0 +1,19 @@
+---
+layout: news_item
+title: "Ion CLI now available through Homebrew"
+date: 2022-08-24
+categories: news ion-cli
+---
+
+The [Ion CLI](https://github.com/amzn/ion-cli) is now available to install using Homebrew, a free and open-source software package management system for macOS and Linux.
+
+To install the latest version of Ion CLI (currently [v0.4.1](https://github.com/amzn/ion-cli/releases/tag/v0.4.1)), run:
+```shell
+brew tap amazon-ion/ion-cli
+brew install ion-cli
+```
+
+If you have any suggestions or encounter any problems using the Ion CLI, [create an issue in `ion-cli`](https://github.com/amzn/ion-cli/issues/new).
+For issues specifically related to installing via Homebrew, [create an issue in `homebrew-ion-cli`](https://github.com/amazon-ion/homebrew-ion-cli/issues/new/choose).
+
+To learn more about using Homebrew in general, visit [brew.sh](https://brew.sh/).


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

Adds a news post for Ion CLI Homebrew tap. You can see the rendered view [here](https://popematt.github.io/ion-docs/news/ion-cli/2022/08/24/ion-cli-homebrew.html).

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
