### PR TITLE
Clarify Expectations for ANTLR Text Grammar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ tags
 !.vscode/launch.json
 !.vscode/extensions.json
 .history
+
+### Java Builds (to test grammar) copy the grammar to here
+grammar/IonText.g4

--- a/docs.md
+++ b/docs.md
@@ -49,7 +49,7 @@ This document covers the Amazon Ion data model and the Ion text format.
 
 [ANTLR grammar][3]
 
-This grammar formally covers the text Ion format.
+This grammar formally covers the text Ion format. It is intended to aid in understanding and provide a machine readable description that is mostly complete and correct. It is not considered authoritative.
 
 ---
 

--- a/docs.md
+++ b/docs.md
@@ -49,7 +49,7 @@ This document covers the Amazon Ion data model and the Ion text format.
 
 [ANTLR grammar][3]
 
-This grammar formally covers the text Ion format. It is intended to aid in understanding and provide a machine readable description that is mostly complete and correct. It is not considered authoritative.
+This grammar formally covers the text Ion format. It is intended to aid in understanding and provide a machine readable description that is mostly complete and correct. It is not considered authoritative, though that is a goal. Known gaps and ambiguities are documented as comments.
 
 ---
 

--- a/grammar/IonText.g4.txt
+++ b/grammar/IonText.g4.txt
@@ -1,15 +1,21 @@
 // Ion Text 1.0 ANTLR v4 Grammar
 //
-// The following grammar does not encode all of the Ion semantics, in particular:
-//
+// The following grammar does not encode the Ion Text semantics completely or
+// unambiguously.
+
+// Known gaps:
 //   * Timestamps are syntactically defined but the rules of ISO 8601 need to be
 //     applied (especially regarding day rules with months and leap years).
 //   * Non $ion_1_0 version markers are not trapped (e.g. $ion_1_1, $ion_2_0)
+//   * The semantics of Symbol Ids, Local Symbol Table defines and imports are not validated
 //   * Edge cases around Unicode semantics:
 //      - ANTLR specifies only four hex digit unicode escapes and on Java operates
 //        on UTF-16 code units (this is a flaw in ANTLR).
 //      - The grammar doesn't validate unpaired surrogate escapes in symbols or strings
 //        (e.g. "\udc00")
+//   * There are some ambiguities involving symbol operators within s-expressions
+//      - Do '-' and '+' (possibly others) right or left associate?
+//      - Do symbol operators terminate special float symbols (nan, -inf, +inf)?
 
 grammar IonText;
 


### PR DESCRIPTION
Adds to description of ANTLR Grammar to make clear that it is intended
to be illustrative, not authoritative.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
