### PR TITLE
Amend Supported Unicode Text Encodings

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -7,8 +7,7 @@ description: "An explanation of the Amazon Ion text encoding."
 # [Docs][docs]/ {{ page.title }}
 
 A [value stream][glossary-value-stream] in the text encoding must be a
-valid sequence of Unicode code points in any of the three encoding forms
-(i.e. UTF-8, UTF-16, or UTF-32).
+valid sequence of UTF-8 code points.
 
 ## ANTLR Grammar {#grammar}
 


### PR DESCRIPTION
This change removes the stated support for UTF-16 and UTF-32,
reflecting a similar change in the JSON specification over time.

RFC 7159 Sec. 8.1 specified that JSON text SHALL be encoded in UTF-8,
UTF-16, or UTF-32. In 2017 RFC 8259 revised Sec. 8.1 to reflect that
JSON text MUST be encoded as UTF-8 when "exchanged between systems
that are not part of a closed ecosystem"

No Ion implementations support non-UTF-8 encodings.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
