### PR TITLE
Update amzn organization to amazon-ion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ion-docs
 
-This repository contains the content behind http://amzn.github.io/ion-docs/, including the Ion specification, documentation, and news.  Feel free to ask questions and propose clarifications, and we'll do our best to respond in a timely fashion.
+This repository contains the content behind http://amazon-ion.github.io/ion-docs/, including the Ion specification, documentation, and news.  Feel free to ask questions and propose clarifications, and we'll do our best to respond in a timely fashion.
 
 ## Development
 

--- a/_data/libraries.json
+++ b/_data/libraries.json
@@ -4,7 +4,7 @@
     "category": "core",
     "latest_release_version": "1.1.0",
     "latest_release_date": "2022-12-06",
-    "documentation": "https://amzn.github.io/ion-c/"
+    "documentation": "https://amazon-ion.github.io/ion-c/"
   },
   {
     "name": "ion-dotnet",
@@ -24,7 +24,7 @@
     "category": "core",
     "latest_release_version": "4.3.0",
     "latest_release_date": "2022-05-10",
-    "documentation": "https://amzn.github.io/ion-js/api/"
+    "documentation": "https://amazon-ion.github.io/ion-js/api/"
   },
   {
     "name": "ion-rust",

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,17 +1,17 @@
 <footer class="site-footer">
   <div class="wrapper">
     <p>
-      <a href="https://github.com/amzn/ion-c">Ion C</a>
-      | <a href="https://github.com/amzn/ion-dotnet">Ion .NET</a>
-      | <a href="https://github.com/amzn/ion-go">Ion Go</a>
-      | <a href="https://github.com/amzn/ion-java">Ion Java</a>
-      | <a href="https://github.com/amzn/ion-js">Ion JavaScript</a>
-      | <a href="https://github.com/amzn/ion-python">Ion Python</a>
+      <a href="https://github.com/amazon-ion/ion-c">Ion C</a>
+      | <a href="https://github.com/amazon-ion/ion-dotnet">Ion .NET</a>
+      | <a href="https://github.com/amazon-ion/ion-go">Ion Go</a>
+      | <a href="https://github.com/amazon-ion/ion-java">Ion Java</a>
+      | <a href="https://github.com/amazon-ion/ion-js">Ion JavaScript</a>
+      | <a href="https://github.com/amazon-ion/ion-python">Ion Python</a>
     </p>
     <p>
-      <a href="https://amzn.github.io/ion-docs">Ion</a>
-      | <a href="https://amzn.github.io/ion-hash">Ion Hash</a>
-      | <a href="https://amzn.github.io/ion-schema">Ion Schema</a>
+      <a href="https://amazon-ion.github.io/ion-docs">Ion</a>
+      | <a href="https://amazon-ion.github.io/ion-hash">Ion Hash</a>
+      | <a href="https://amazon-ion.github.io/ion-schema">Ion Schema</a>
     </p>
     <p>
       Copyright 2009-{{ 'now' | date: "%Y" }} Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/_includes/library_table.md
+++ b/_includes/library_table.md
@@ -5,7 +5,7 @@
   {%- assign name = row["name"] -%}
   {%- capture release -%}
     {%- if row["latest_release_version"] -%}
-      [{{ row["latest_release_version"] }}](https://github.com/amzn/{{ name }}/releases/latest) ({{ row["latest_release_date"] | date: "%B %d, %Y" }})
+      [{{ row["latest_release_version"] }}](https://github.com/amazon-ion/{{ name }}/releases/latest) ({{ row["latest_release_date"] | date: "%B %d, %Y" }})
     {%- else -%}
       in development
     {%- endif -%}
@@ -18,7 +18,7 @@
     {%- endif -%}
   {%- endcapture -%}
   {%- capture repository -%}
-    [Link](https://github.com/amzn/{{ name }})
+    [Link](https://github.com/amazon-ion/{{ name }})
   {%- endcapture -%}
   | {{ name }} | {{ release }} | {{ repository }} | {{ documentation }}
 {% endfor %}

--- a/_scripts/generate_release_news.sh
+++ b/_scripts/generate_release_news.sh
@@ -57,7 +57,7 @@ for repo_name in $REPO_NAMES; do
   [[ $GITHUB_ACTIONS ]] && echo "::group::$repo_name"
 
   echo "Checking for releases in $repo_name"
-  release="$(gh release view -R "amzn/$repo_name" --json body,createdAt,tagName)"
+  release="$(gh release view -R "amazon-ion/$repo_name" --json body,createdAt,tagName)"
   if [[ -z "$release" ]]; then
     [[ $GITHUB_ACTIONS ]] && echo "::endgroup::"
     continue
@@ -91,7 +91,7 @@ categories: news $repo_name
 
 $title_case_repo_name $version is now available.
 
-| [Release Notes $tag](https://github.com/amzn/$repo_name/releases/tag/$tag) | [$title_case_repo_name](https://github.com/amzn/$repo_name) |
+| [Release Notes $tag](https://github.com/amazon-ion/$repo_name/releases/tag/$tag) | [$title_case_repo_name](https://github.com/amazon-ion/$repo_name) |
 " >> "$news_item_file_path"
 
     git add "$news_item_file_path"

--- a/assets/ion-widget.js
+++ b/assets/ion-widget.js
@@ -21,7 +21,7 @@
       + '<textarea rows="20" cols="60" id="ion-source-' + id + '" style="border: 1px solid lightgrey; background: white; color: black; padding: 5px; line-height: 1.3em">' + ionSource.innerHTML + '</textarea></td>'
       + '<td width="50%" style="padding: 0px"><code id="ion-text-' + id + '" style="display: block; white-space: pre-wrap"></code></td>'
       + '</tr>'
-      + '<tr><td align="center"><button id="btn-ion-parse-' + id + '">parse</button></td><td align="right"><font size="-1">made with <a href="https://github.com/amzn/ion-js">ion-js</a></font></td></tr>'
+      + '<tr><td align="center"><button id="btn-ion-parse-' + id + '">parse</button></td><td align="right"><font size="-1">made with <a href="https://github.com/amazon-ion/ion-js">ion-js</a></font></td></tr>'
       + '</table>';
   ionSource.parentNode.replaceChild(widget, ionSource);
 

--- a/guides/cookbook.md
+++ b/guides/cookbook.md
@@ -2499,7 +2499,7 @@ openTab('Java');  // default tab
 </script>
 
 <!-- References -->
-[1]: https://github.com/amzn/ion-java
+[1]: https://github.com/amazon-ion/ion-java
 [2]: https://www.javadoc.io/doc/com.amazon.ion/ion-java/
 [3]: https://www.javadoc.io/doc/com.amazon.ion/ion-java/latest/com/amazon/ion/IonSystem.html
 [4]: https://www.javadoc.io/doc/com.amazon.ion/ion-java/latest/com/amazon/ion/IonReader.html
@@ -2512,14 +2512,14 @@ openTab('Java');  // default tab
 [11]: https://docs.oracle.com/javase/8/docs/api/java/io/ByteArrayOutputStream.html
 [12]: https://docs.oracle.com/javase/8/docs/api/java/math/BigInteger.html
 [13]: https://docs.oracle.com/javase/8/docs/api/java/io/BufferedReader.html
-[14]: https://amzn.github.io/ion-c/
+[14]: https://amazon-ion.github.io/ion-c/
 [15]: https://www.javadoc.io/doc/com.amazon.ion/ion-java/latest/com/amazon/ion/system/IonBinaryWriterBuilder.html
 [16]: https://www.javadoc.io/doc/com.amazon.ion/ion-java/latest/com/amazon/ion/system/IonReaderBuilder.html
 [17]: {{ site.baseurl }}/docs.html
-[18]: https://amzn.github.io/ion-js/api/
-[19]: https://amzn.github.io/ion-js/api/interfaces/_ionreader_.reader.html
-[20]: https://amzn.github.io/ion-js/api/interfaces/_ionwriter_.writer.html
+[18]: https://amazon-ion.github.io/ion-js/api/
+[19]: https://amazon-ion.github.io/ion-js/api/interfaces/_ionreader_.reader.html
+[20]: https://amazon-ion.github.io/ion-js/api/interfaces/_ionwriter_.writer.html
 [21]: https://ion-python.readthedocs.io/en/latest/index.html
-[22]: https://github.com/amzn/ion-go/blob/master/ion/reader.go
-[23]: https://github.com/amzn/ion-go/blob/master/ion/writer.go
-[24]: https://pkg.go.dev/github.com/amzn/ion-go/ion
+[22]: https://github.com/amazon-ion/ion-go/blob/master/ion/reader.go
+[23]: https://github.com/amazon-ion/ion-go/blob/master/ion/writer.go
+[24]: https://pkg.go.dev/github.com/amazon-ion/ion-go/ion

--- a/guides/path-extractor-guide.md
+++ b/guides/path-extractor-guide.md
@@ -8,12 +8,12 @@ description: "A guide to implementing path extraction APIs."
 This document provides a guide to implementing a path extraction API as
 an alternative to the traditional streaming and DOM APIs. A reference
 implementation exists in ion-c (see
-[1](https://github.com/amzn/ion-c/blob/master/ionc/inc/ion_extractor.h),
-[2](https://github.com/amzn/ion-c/blob/master/ionc/ion_extractor_impl.h),
+[1](https://github.com/amazon-ion/ion-c/blob/master/ionc/include/ionc/ion_extractor.h),
+[2](https://github.com/amazon-ion/ion-c/blob/master/ionc/ion_extractor_impl.h),
 and
-[3](https://github.com/amzn/ion-c/blob/master/ionc/ion_extractor.c)) and
+[3](https://github.com/amazon-ion/ion-c/blob/master/ionc/ion_extractor.c)) and
 it's also available as an
-[extension to ion-java](https://github.com/amzn/ion-java-path-extraction).
+[extension to ion-java](https://github.com/amazon-ion/ion-java-path-extraction).
 
 Motivation
 ----------

--- a/help.md
+++ b/help.md
@@ -28,7 +28,7 @@ Each [library](libs.html) repo has a contributing file that provides instruction
 
 ### Do I have to create a schema in order to use Ion?
 
-> No.  Working with Ion does not require the use of schemas.  However, use cases for which constraining the universe of Ion values is helpful may utilize [Ion Schema](https://amzn.github.io/ion-schema/).
+> No.  Working with Ion does not require the use of schemas.  However, use cases for which constraining the universe of Ion values is helpful may utilize [Ion Schema](https://amazon-ion.github.io/ion-schema/).
 
 ### How can I concatenate streams of Ion data?
 

--- a/index.md
+++ b/index.md
@@ -145,10 +145,10 @@ To learn more, check out the [Docs][8] page, or see [Libs][12] for the officiall
 <!-- References -->
 [1]: http://json.org
 [2]: guides/why.html
-[3]: https://github.com/amzn/ion-java
-[4]: https://github.com/amzn/ion-c
-[5]: https://github.com/amzn/ion-python
-[6]: https://github.com/amzn/ion-js
+[3]: https://github.com/amazon-ion/ion-java
+[4]: https://github.com/amazon-ion/ion-c
+[5]: https://github.com/amazon-ion/ion-python
+[6]: https://github.com/amazon-ion/ion-js
 [7]: news.html
 [8]: docs.html
 [9]: help.html
@@ -159,11 +159,11 @@ To learn more, check out the [Docs][8] page, or see [Libs][12] for the officiall
 [14]: guides/why.html#dual-format-interoperability
 [15]: guides/why.html#self-describing
 [16]: guides/why.html#read-optimized-binary-format
-[17]: https://amzn.github.io/ion-schema
-[18]: https://github.com/amzn/ion-hive-serde
-[19]: https://amzn.github.io/ion-hash
-[20]: https://github.com/amzn/ion-dotnet
-[21]: https://github.com/amzn/ion-go
-[22]: https://github.com/amzn/ion-rust
+[17]: https://amazon-ion.github.io/ion-schema
+[18]: https://github.com/amazon-ion/ion-hive-serde
+[19]: https://amazon-ion.github.io/ion-hash
+[20]: https://github.com/amazon-ion/ion-dotnet
+[21]: https://github.com/amazon-ion/ion-go
+[22]: https://github.com/amazon-ion/ion-rust
 [23]: https://github.com/libmir/mir-ion
 [24]: https://github.com/awesomized/ext-ion

--- a/libs.md
+++ b/libs.md
@@ -22,10 +22,10 @@ description: "The latest news about Amazon Ion and the Amazon Ion community."
 
 | Name | Repository | Release |
 |------|------|---------|
-| ion-eclipse-plugin | [Link](https://github.com/amzn/ion-eclipse-plugin) | - |
-| ion-intellij-plugin | [Link](https://github.com/amzn/ion-intellij-plugin) | [Link](https://plugins.jetbrains.com/plugin/8409-amazon-ion-intellij-idea-plugin) |
-| ion-test-driver | [Link](https://github.com/amzn/ion-test-driver) | - |
-| ion-tests | [Link](https://github.com/amzn/ion-tests) | - |
+| ion-eclipse-plugin | [Link](https://github.com/amazon-ion/ion-eclipse-plugin) | - |
+| ion-intellij-plugin | [Link](https://github.com/amazon-ion/ion-intellij-plugin) | [Link](https://plugins.jetbrains.com/plugin/8409-amazon-ion-intellij-idea-plugin) |
+| ion-test-driver | [Link](https://github.com/amazon-ion/ion-test-driver) | - |
+| ion-tests | [Link](https://github.com/amazon-ion/ion-tests) | - |
 
 ## Community Supported Libraries
 


### PR DESCRIPTION
### Issue #, if available: amazon-ion/ion-c#313

### Description of changes:
This PR updates the `amzn` organization used for URLs in the libs documentation to the new `amazon-ion` org.

This was done primarily in response to ion-c's documentation link being broken, but on review I noticed ion-js also had broken documentation, so I went ahead and updated all links, now that I believe everything has been moved over.

I also went through the links elsewhere in the docs and updated any link that was not related to the ion-go package documentation or code.

There was also an ion-c link that looked out of date, for the path extractor API, so I updated that as well.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
