### PR TITLE
Correct Explanation of Problem with Storing Decimal as Float

### DIFF
--- a/docs/decimal.md
+++ b/docs/decimal.md
@@ -7,9 +7,9 @@ description: "Amazon Ion supports a decimal numeric type to allow accurate repre
 # [Docs][docs]/ {{ page.title }}
 
 Amazon Ion supports a decimal numeric type to allow accurate representation
-of base-10 floating point values such as currency amounts. This
-representation preserves significant trailing zeros when converting
-between text and binary forms.
+of base-10 floating point values such as currency amounts. An Ion Decimal
+has arbitrary precision and scale. This representation preserves significant
+trailing zeros when converting between text and binary forms.
 
 Decimals are supported in addition to the traditional base-2 floating point
 type (see Ion `float`). This avoids the loss of exactness often incurred when

--- a/docs/decimal.md
+++ b/docs/decimal.md
@@ -12,10 +12,9 @@ representation preserves significant trailing zeros when converting
 between text and binary forms.
 
 Decimals are supported in addition to the traditional base-2 floating point
-type (see Ion `float`) to avoid the loss of precision associated with
-converting base-10 fractional values to base-2 fractional values. Sadly,
-base-10 is relatively prime to base-2; many commonly-used base-10 rational
-numbers are irrational in base-2.
+type (see Ion `float`). This avoids the loss of exactness often incurred when
+storing a decimal fraction as a binary fraction. Many common decimal numbers with 
+relatively few digits cannot be represented as a terminating binary fraction.
 
 * TOC
 {:toc}


### PR DESCRIPTION
The previous explanation used the terms "rational" and "irrational"
and was not correct. A rational number is rational in all bases.

This is my attempt at a more correct *brief* description.

### Issue #, if available:

### Description of changes:

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
