### PR TITLE
Remove mention of comma from sexp description.

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -633,9 +633,8 @@ statements. As such, correct interpretation requires a higher-level
 context other than the raw Ion parser and data model.
 
 In the text format, S-expressions are bounded by parentheses.
-S-expressions also allow unquoted operator symbols (in addition to the
-unquoted identifier symbols allowed everywhere), so commas are
-interpreted as values rather than element separators.
+S-expressions also allow unquoted operator symbols, in addition to the
+unquoted identifier symbols allowed everywhere.
 
 ```
 null.sexp         // A null S-expression value


### PR DESCRIPTION
Commas are not valid operator characters.

This documentation defect dates back to 2007-04-24 when we removed comma from the set of operator characters. We felt it risked confusion and ambiguity for `[1, 2]` to have two elements but `(1, 2)` to have three.  (We simultaneously removed colon, for similar (but arguably less convincing) reasons.)

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
