### PR TITLE
Ion 1.1 binary encoding specification

### DIFF
--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -326,7 +326,7 @@ The meanings of each opcode are organized loosely by their high and low nibbles.
 <|Delimited struct with `VarSym` field names start
 
 |`4`
-<|Reserved
+<|Variable length prefixed macro invocation
 
 |`5`
 <|Variable length integer
@@ -356,10 +356,10 @@ The meanings of each opcode are organized loosely by their high and low nibbles.
 <|Variable length struct with `VarSym` field names
 
 |`E`
-<|Reserved
+<|Variable length blob
 
 |`F`
-<|Variable length prefixed macro invocation
+<|Variable length clob
 
 |===
 
@@ -1047,24 +1047,329 @@ address that is decoded is biased by the number of addresses that can be encoded
 |16,641
 |===
 
-
 [[binary_data]]
 == Binary data
 
 [[blobs]]
 === Blobs
 
+Opcode `FE` indicates a blob of binary data.
+
+==== Example encoding of a 24-byte blob
+[source]
+----
+┌──── Opcode FE indicates a blob, VarUInt length follows
+│   ┌─── Length: VarUInt 24
+│   │
+FE 31 49 20 61 70 70 6c 61 75 64 20 79 6f 75 72 20 63 75 72 69 6f 73 69 74 79
+      └────────────────────────────────┬────────────────────────────────────┘
+                            24 bytes of binary data
+----
+
+
 [[clobs]]
 === Clobs
+
+Opcode `FF` indicates a clob--character data of an unspecified encoding.
+
+==== Example encoding of a 24-byte clob
+[source]
+----
+┌──── Opcode FF indicates a clob, VarUInt length follows
+│   ┌─── Length: VarUInt 24
+│   │
+FF 31 49 20 61 70 70 6c 61 75 64 20 79 6f 75 72 20 63 75 72 69 6f 73 69 74 79
+      └────────────────────────────────┬────────────────────────────────────┘
+                            24 bytes of binary data
+----
 
 [[containers]]
 == Containers
 
+Each of the container types (list, s-expression, and struct) has both a length-prefixed encoding and a delimited
+encoding.
+
+The length-prefixed encoding places more burden on the writer, but simplifies reading and enables skipping
+over uninteresting values in the data stream. In contrast, the delimited encoding is simpler and faster for
+writers, but requires the reader to visit each child value in turn to skip over the container.
+
 [[lists]]
 === Lists
+
+==== Length-prefixed encoding
+
+An opcode with a high nibble of `0xA_` indicates a length-prefixed list. The lower nibble of the
+opcode indicates how many bytes were used to encode the child values that the list contains.
+
+If the list's encoded byte-length is too large to be encoded in a nibble, writers may use the `0xFA` opcode
+to write a variable-length list. The `0xFA` opcode is followed by a
+<<varuint, `VarUInt`>> that indicates the list's byte length.
+
+===== Example length-prefixed encoding of an empty list (`[]`)
+[source]
+----
+┌──── An Opcode in the range 0xA0-0xAF indicates a list.
+│┌─── A low nibble of 0 indicates that the child values of this list took zero bytes to encode.
+A0
+----
+
+===== Example encoding of `[1, 2, 3]`
+[source]
+----
+┌──── An Opcode in the range 0xA0-0xAF indicates a list.
+│┌─── A low nibble of 0 indicates that the child values of this list took zero bytes to encode.
+A6 51 01 51 02 51 03
+   └─┬─┘ └─┬─┘ └─┬─┘
+     1     2     3
+----
+
+===== Example encoding of `["variable length list"]`
+[source]
+----
+┌──── Opcode 0xFA indicates a variable-length list. A VarUInt length follows.
+│  ┌───── Length: VarUInt 22
+│  │  ┌────── Opcode 0xF8 indicates a variable-length string. A VarUInt length follows.
+│  │  │  ┌─────── Length: VarUInt 20
+│  │  │  │   v  a  r  i  a  b  l  e     l  e  n  g  t  h     l  i  s  t
+FA 2d F8 29 76 61 72 69 61 62 6c 65 20 6c 65 6e 67 74 68 20 6c 69 73 74
+      └─────────────────────────────┬─────────────────────────────────┘
+                          Nested string element
+----
+
+==== Delimited encoding
+
+Opcode `0xF1` begins a delimited list, while opcode `0xF0` closes the most recently opened delimited container
+that has not yet been closed.
+
+===== Example delimited encoding of an empty list (`[]`)
+[source]
+----
+┌──── Opcode 0xF1 indicates a delimited list
+│  ┌─── Opcode 0xF0 indicates the end of the most recently opened container
+F1 F0
+----
+
+===== Example encoding of `[1, 2, 3]`
+[source]
+----
+┌──── Opcode 0xF1 indicates a delimited list
+│                    ┌─── Opcode 0xF0 indicates the end of
+│                    │    the most recently opened container
+F1 51 01 51 02 51 03 F0
+   └─┬─┘ └─┬─┘ └─┬─┘
+     1     2     3
+----
+
+===== Example encoding of `[1, [2], 3]`
+[source]
+----
+┌──── Opcode 0xF1 indicates a delimited list
+│        ┌─── Opcode 0xF1 begins a nested delimited list
+│        │        ┌─── Opcode 0xF0 closes the most recently
+│        │        │    opened delimited container: the nested list.
+│        │        │        ┌─── Opcode 0xF0 closes the most recently opened (and still open)
+│        │        │        │    delimited container: the outer list.
+│        │        │        │
+F1 51 01 F1 51 02 F0 51 03 F0
+   └─┬─┘    └─┬─┘    └─┬─┘
+     1        2        3
+----
 
 [[s_expressions]]
 === S-expressions
 
+==== Length-prefixed encoding
+
+An opcode with a high nibble of `0xB_` indicates a length-prefixed S-expression. The lower nibble of the
+opcode indicates how many bytes were used to encode the child values that the S-expression contains.
+
+If the S-expression's encoded byte-length is too large to be encoded in a nibble, writers may use
+the `0xFB` opcode to write a variable-length S-expression. The `0xFB` opcode is followed by a
+<<varuint, `VarUInt`>> that indicates the S-expression's byte length.
+
+===== Example length-prefixed encoding of an empty S-expression (`()`)
+[source]
+----
+┌──── An Opcode in the range 0xB0-0xBF indicates an S-expression.
+│┌─── A low nibble of 0 indicates that the child values of this S-expression took zero bytes to encode.
+B0
+----
+
+===== Example encoding of `(1 2 3)`
+[source]
+----
+┌──── An Opcode in the range 0xB0-0xBF indicates an S-expression.
+│┌─── A low nibble of 6 indicates that the child values of this S-expression took six bytes to encode.
+B6 51 01 51 02 51 03
+   └─┬─┘ └─┬─┘ └─┬─┘
+     1     2     3
+----
+
+===== Example encoding of `("variable length sexp")`
+[source]
+----
+┌──── Opcode 0xFB indicates a variable-length list. A VarUInt length follows.
+│  ┌───── Length: VarUInt 22
+│  │  ┌────── Opcode 0xF8 indicates a variable-length string. A VarUInt length follows.
+│  │  │  ┌─────── Length: VarUInt 20
+│  │  │  │   v  a  r  i  a  b  l  e     l  e  n  g  t  h     s  e  x  p
+FB 2d F8 29 76 61 72 69 61 62 6c 65 20 6c 65 6e 67 74 68 20 73 65 78 70
+      └─────────────────────────────┬─────────────────────────────────┘
+                          Nested string element
+----
+
+==== Delimited encoding
+
+Opcode `0xF2` begins a delimited S-expression, while opcode `0xF0` closes the most recently opened
+delimited container that has not yet been closed.
+
+===== Example delimited encoding of an empty S-expression (`()`)
+[source]
+----
+┌──── Opcode 0xF2 indicates a delimited S-expression
+│  ┌─── Opcode 0xF0 indicates the end of the most recently opened container
+F2 F0
+----
+
+===== Example encoding of `(1 2 3)`
+[source]
+----
+┌──── Opcode 0xF2 indicates a delimited S-expression
+│                    ┌─── Opcode 0xF0 indicates the end of
+│                    │    the most recently opened container
+F2 51 01 51 02 51 03 F0
+   └─┬─┘ └─┬─┘ └─┬─┘
+     1     2     3
+----
+
+===== Example encoding of `(1 (2) 3)`
+[source]
+----
+┌──── Opcode 0xF2 indicates a delimited S-expression
+│        ┌─── Opcode 0xF2 begins a nested delimited S-expression
+│        │        ┌─── Opcode 0xF0 closes the most recently
+│        │        │    opened delimited container: the nested S-expression.
+│        │        │        ┌─── Opcode 0xF0 closes the most recently opened (and still open)
+│        │        │        │    delimited container: the outer S-expression.
+│        │        │        │
+F2 51 01 F2 51 02 F0 51 03 F0
+   └─┬─┘    └─┬─┘    └─┬─┘
+     1        2        3
+----
+
 [[structs]]
 === Structs
+
+Structs have 3 available encodings:
+
+. Structs with symbol address field names
+. Structs with <<varsym, `VarSym`>> field names
+. Delimited structs with `VarSym` field names
+
+[[structs_with_symbol_address_field_names]]
+==== Structs with symbol address field names
+
+An opcode with a high nibble of `0xC_` indicates a struct with symbol address field names. The lower
+nibble of the opcode indicates how many bytes were used to encode all of its nested `(field name, value)`
+pairs.
+
+If the struct's encoded byte-length is too large to be encoded in a nibble, writers may use the `0xFC` opcode
+to write a variable-length struct with symbol address field names. The `0xFC` opcode is followed by a
+<<varuint, `VarUInt`>> that indicates the byte length.
+
+Each field in the struct is encoded as a <<varuint, `VarUInt`>> representing the address of the field name's
+text in the symbol table, followed by an opcode-prefixed value.
+
+===== Example encoding of an empty struct (`{}`)
+[source]
+----
+┌──── An opcode in the range 0xC0-0xCF indicates a struct with symbol address field names
+│┌─── A lower nibble of 0 indicates that the struct's fields took zero bytes to encode
+C0
+----
+
+===== Example encoding of `{$10: 1, $11: 2}`
+[source]
+----
+┌──── An opcode in the range 0xC0-0xCF indicates a struct with symbol address field names
+│  ┌─── Field name: VarUInt 10 ($10)
+│  │        ┌─── Field name: VarUInt 11 ($11)
+│  │        │
+C6 15 51 01 17 51 02
+      └─┬─┘    └─┬─┘
+        1        2
+----
+
+===== Example encoding of `{$10: "variable length struct"}`
+[source]
+----
+ ┌───────────── Opcode `FC` indicates a variable length struct with symbol address field names
+ │  ┌────────── Length: VarUInt 25
+ │  │  ┌─────── Field name: VarUInt 10 ($10)
+ │  │  │  ┌──── Opcode `F8` indicates a variable length string
+ │  │  │  │  ┌─ VarUInt: 22 the string is 22 bytes long
+ │  │  │  │  │  v  a  r  i  a  b  l  e     l  e  n  g  t  h     s  t  r  u  c  t
+FC 33 15 F8 2D 76 61 72 69 61 62 6c 65 20 6c 65 6e 67 74 68 20 73 74 72 75 63 74
+               └─────────────────────────────┬─────────────────────────────────┘
+                                        UTF-8 bytes
+----
+
+[[structs_with_varsym_field_names]]
+==== Structs with `VarSym` field names
+
+NOTE: This encoding is very similar to <<structs_with_symbol_address_field_names, structs with symbol address
+field names>>, but allows writers to choose between representing each field name as a symbol address
+(for example: `$10`) or inline UTF-8 bytes (for example: `"foo"`). This encoding is potentially less
+dense, but offers writers significant flexibility over whether and when field names are added to the
+symbol table.
+
+An opcode with a high nibble of `0xD_` indicates a struct with <<varsym, `VarSym`>> field names. The lower
+nibble of the opcode indicates how many bytes were used to encode all of its nested `(field name, value)`
+pairs.
+
+WARNING: Empty structs MUST be written using `0xC0`. `0xD0` is a reserved opcode.
+
+If the struct's encoded byte-length is too large to be encoded in a nibble, writers may use the `0xFD` opcode
+to write a variable-length struct with <<varsym, `VarSym`>> field names. The `0xFD` opcode is followed by a
+<<varuint, `VarUInt`>> that indicates the byte length.
+
+Each field in the struct is encoded as a  <<varsym, `VarSym`>> field name, followed by an
+opcode-prefixed value.
+
+===== Example encoding of `{"foo": 1, $11: 2}`
+[source]
+----
+┌─── Opcode with high nibble `D` indicates a struct with VarSym field names
+│┌── Length: 7
+││ ┌─ VarSym -3      ┌─ VarSym: 11 ($11)
+││ │   f  o  o       │
+D9 FD 66 6F 6F 51 01 17 91 02
+      └──┬───┘ └─┬─┘    └─┬─┘
+      3 UTF-8    1        2
+       bytes
+----
+
+// TODO: Demonstrate splicing macro values into the struct via VarSym escape code `0x00`.
+
+[[delimited_structs]]
+==== Delimited structs
+
+Opcode `0xF3` indicates the beginning of a delimited struct with `VarSym` field names,
+while opcode `0xF0` closes the most recently opened delimited container that has not yet been closed.
+
+NOTE: There is no delimited encoding for structs with symbol address field names.
+
+===== Example encoding of `{"foo": 1, $11: 2}`
+[source]
+----
+┌─── Opcode 0xF3 indicates the beginning of a delimited struct with `VarSym` field names.
+│
+│  ┌─ VarSym -3      ┌─ VarSym: 11 ($11)
+│  │                 │
+│  │                 │         ┌─ Opcode 0xF0 indicates the end of the most
+│  │   f  o  o       │         │  recently opened delimited container
+F3 FD 66 6F 6F 51 01 17 91 02 F0
+      └──┬───┘ └─┬─┘    └─┬─┘
+      3 UTF-8    1        2
+       bytes
+----

--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -159,12 +159,17 @@ expansion.
 
 A `VarSym` begins with a <<varint,`VarInt`>>; once this integer has been read, we can evaluate it to determine how to proceed. If the VarInt is:
 
-* *greater than zero*, it represents a symbol ID. The symbol’s associated text can be found in the local symbol table. No more bytes follow.
-* *less than zero*, its absolute value represents a number of UTF-8 bytes that follow the `VarInt`. These bytes represent the symbol’s text.
-* *exactly zero*, another byte follows that is an <<opcodes, opcode>>. The `VarSym` parser is not responsible for evaluating this opcode, only returning it—the caller will decide whether the opcode is legal in the current context. Example usages of the opcode include:
+* *greater than zero*, it represents a symbol ID. The symbol’s associated text can be found in the local symbol table.
+No more bytes follow.
+* *less than zero*, its absolute value represents a number of UTF-8 bytes that follow the `VarInt`. These bytes
+represent the symbol’s text.
+* *exactly zero*, another byte follows that is an <<opcodes, opcode>>. The `VarSym` parser is not responsible for
+evaluating this opcode, only returning it—the caller will decide whether the opcode is legal in the current context.
+Example usages of the opcode include:
 ** Representing SID `$0` as `0x70`
 ** Representing the empty string (`""`) as `0x80`
-** When used to encode a struct field name, the opcode can invoke a macro that will evaluate to a struct whose key/value pairs are spliced into the parent struct (TODO: Link)
+** When used to encode a struct field name, the opcode can invoke a macro that will evaluate to a struct whose key/value
+pairs are spliced into the parent struct (TODO: Link)
 ** In a delimited struct, terminating the sequence of (name, value) pairs with `0xAD`. (TODO: Link)
 
 ==== Example encoding of a `VarSym` with symbol ID `$10` ====
@@ -418,10 +423,12 @@ F4 05 50 fc
 Float values are encoded using the IEEE-754 specification, and can be serialized in four sizes:
 
 * 0 bits (0 bytes), representing the value 0e0 and indicated by opcode `0x5A`
-* 16 bits (2 bytes, link:https://en.wikipedia.org/wiki/Half-precision_floating-point_format[half precision]), indicated
-by opcode `0x5B`
-* 32 bits (4 bytes, link:https://en.wikipedia.org/wiki/Single-precision_floating-point_format[single precision]), indicated by opcode `0x5C`
-* 64 bits (8 bytes, link:https://en.wikipedia.org/wiki/Double-precision_floating-point_format[double precision]), indicated by opcode `0x5D`
+* 16 bits (2 bytes, link:https://en.wikipedia.org/wiki/Half-precision_floating-point_format[half precision]),
+indicated by opcode `0x5B`
+* 32 bits (4 bytes, link:https://en.wikipedia.org/wiki/Single-precision_floating-point_format[single precision]),
+indicated by opcode `0x5C`
+* 64 bits (8 bytes, link:https://en.wikipedia.org/wiki/Double-precision_floating-point_format[double precision]),
+indicated by opcode `0x5D`
 
 Note that in the Ion data model, float values are always 64 bits. However, if a value can be losslessly serialized
 in fewer than 64 bits, applications may choose to do so.
@@ -625,7 +632,9 @@ consume only enough bits to represent the fractional precision supported by the 
 
 ==== Opcode `0x73`: Hour+Minutes @ UTC or Unknown (4 bytes)
 
-NOTE: Each encoding for a precision greater than or equal to `Hour+Minutes` comes in two flavors: one that uses a single bit (`U`) to indicate UTC versus Unknown offset, and another that uses 7 bits (`o`) to encode the number of quarter-hours offset from `-14:00`.
+NOTE: Each encoding for a precision greater than or equal to `Hour+Minutes` comes in two flavors: one that uses a single
+bit (`U`) to indicate UTC versus Unknown offset, and another that uses 7 bits (`o`) to encode the number of quarter-hours
+offset from `-14:00`.
 
 [source]
 ----
@@ -661,9 +670,9 @@ NOTE: Each encoding for a precision greater than or equal to `Hour+Minutes` come
 ==== Opcode `0x77`: Milliseconds @ UTC or Unknown (6 bytes)
 [source]
 ----
-+=========+=========+=========+=========+=========+
-|YYYY:YYYM|MMMD:DDDD|HHHH:Hmmm|mmmU:ssss|ss--:----|
-+=========+=========+=========+=========+=========+
++=========+=========+=========+=========+=========+=========+
+|YYYY:YYYM|MMMD:DDDD|HHHH:Hmmm|mmmk:ssss|ssff:ffff|ffff:----|
++=========+=========+=========+=========+=========+=========+
 ----
 
 ==== Opcode `0x78`: Milliseconds @ Offset (7 bytes)
@@ -762,7 +771,8 @@ If the timestamp's length is greater than or equal to `8`, it has fractional sec
 `(coefficient, exponent)` pair, similar to a <<decimals, decimal>>. However, it is illegal for the fractional
 seconds value to be greater than or equal to `1.0` or less than `0.0`. For this reason, both the exponent and
 the coefficient are encoded using unsigned types. The included exponent `VarUInt` is implicitly negative, preventing
-the encoding of decimal numbers greater than `1.0`. The coefficient `FixedUInt` is unsigned to prevent the encoding of fractional seconds less than `0.0`. Note that validation is still required; namely:
+the encoding of decimal numbers greater than `1.0`. The coefficient `FixedUInt` is unsigned to prevent the encoding of
+fractional seconds less than `0.0`. Note that validation is still required; namely:
 
 * An exponent value of `0` is illegal, as that would result in a fractional seconds greater than `1.0` (a whole second).
 * If `coefficient * 10^-exponent > 1.0`, that `(coefficient, exponent)` pair is illegal.

--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -757,11 +757,19 @@ consume only enough bits to represent the fractional precision supported by the 
 | Unused
 |===
 
+NOTE: Timestamps are encoded in Little Endian byte order. In the diagrams below, the bytes are read from left to right
+(least significant to most significant), while the bits within each byte should be read from right to left. (Again
+least significant to most significant.) +
+While this encoding may complicate the diagrams somewhat, it guarantees that the timestamp's subfields (`year`, `month`,
+etc.) occupy the same bit indexes regardless of how many bytes there are overall. (The last subfield,
+`fractional_seconds`, always begins at the same bit index when present, but can vary in length according to the
+precision.)
+
 ==== Opcode `0x70`: Year (1 byte)
 [source]
 ----
 +=========+
-|YYYY:YYY-|
+|-YYY:YYYY|
 +=========+
 ----
 
@@ -769,7 +777,7 @@ consume only enough bits to represent the fractional precision supported by the 
 [source]
 ----
 +=========+=========+
-|YYYY:YYYM|MMM-:----|
+|MYYY:YYYY|----:-MMM|
 +=========+=========+
 ----
 
@@ -777,7 +785,7 @@ consume only enough bits to represent the fractional precision supported by the 
 [source]
 ----
 +=========+=========+
-|YYYY:YYYM|MMMD:DDDD|
+|MYYY:YYYY|DDDD:DMMM|
 +=========+=========+
 ----
 
@@ -790,15 +798,16 @@ offset from `-14:00`.
 [source]
 ----
 +=========+=========+=========+=========+
-|YYYY:YYYM|MMMD:DDDD|HHHH:Hmmm|mmmU:----|
+|MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|----:Ummm|
 +=========+=========+=========+=========+
 ----
 
 ==== Opcode `0x74`: Hour+Minutes @ Offset (5 bytes)
 [source]
 ----
+
 +=========+=========+=========+=========+=========+
-|YYYY:YYYM|MMMD:DDDD|HHHH:Hmmm|mmmo:oooo|oo--:----|
+|MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|oooo:ommm|----:--oo|
 +=========+=========+=========+=========+=========+
 ----
 
@@ -806,7 +815,7 @@ offset from `-14:00`.
 [source]
 ----
 +=========+=========+=========+=========+=========+
-|YYYY:YYYM|MMMD:DDDD|HHHH:Hmmm|mmmU:ssss|ss--:----|
+|MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|ssss:Ummm|----:--ss|
 +=========+=========+=========+=========+=========+
 ----
 
@@ -814,7 +823,7 @@ offset from `-14:00`.
 [source]
 ----
 +=========+=========+=========+=========+=========+
-|YYYY:YYYM|MMMD:DDDD|HHHH:Hmmm|mmmo:oooo|oo--:----|
+|MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|oooo:ommm|ssss:ssoo|
 +=========+=========+=========+=========+=========+
 ----
 
@@ -822,7 +831,7 @@ offset from `-14:00`.
 [source]
 ----
 +=========+=========+=========+=========+=========+=========+
-|YYYY:YYYM|MMMD:DDDD|HHHH:Hmmm|mmmk:ssss|ssff:ffff|ffff:----|
+|MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|ssss:Ummm|ffff:ffss|----:ffff|
 +=========+=========+=========+=========+=========+=========+
 ----
 
@@ -830,7 +839,7 @@ offset from `-14:00`.
 [source]
 ----
 +=========+=========+=========+=========+=========+=========+=========+
-|YYYY:YYYM|MMMD:DDDD|HHHH:Hmmm|mmmo:oooo|ooss:ssss|ffff:ffff|ff--:----|
+|MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|oooo:ommm|ssss:ssoo|ffff:ffff|----:--ff|
 +=========+=========+=========+=========+=========+=========+=========+
 ----
 
@@ -838,7 +847,7 @@ offset from `-14:00`.
 [source]
 ----
 +=========+=========+=========+=========+=========+=========+=========+
-|YYYY:YYYM|MMMD:DDDD|HHHH:Hmmm|mmmk:ssss|ssff:ffff|ffff:ffff|ffff:ff--|
+|MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|ssss:Ummm|ffff:ffss|ffff:ffff|--ff:ffff|
 +=========+=========+=========+=========+=========+=========+=========+
 ----
 
@@ -846,7 +855,7 @@ offset from `-14:00`.
 [source]
 ----
 +=========+=========+=========+=========+=========+=========+=========+=========+
-|YYYY:YYYM|MMMD:DDDD|HHHH:Hmmm|mmmo:oooo|ooss:ssss|ffff:ffff|ffff:ffff|ffff:----|
+|MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|oooo:ommm|ssss:ssoo|ffff:ffff|ffff:ffff|----:ffff|
 +=========+=========+=========+=========+=========+=========+=========+=========+
 ----
 
@@ -854,16 +863,16 @@ offset from `-14:00`.
 [source]
 ----
 +=========+=========+=========+=========+=========+=========+=========+=========+
-|YYYY:YYYM|MMMD:DDDD|HHHH:Hmmm|mmmo:oooo|ooss:ssss|ffff:ffff|ffff:ffff|ffff:----|
+|MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|ssss:Ummm|ffff:ffss|ffff:ffff|ffff:ffff|ffff:ffff|
 +=========+=========+=========+=========+=========+=========+=========+=========+
 ----
 
-==== Opcode `0x7B`: Nanoseconds @ Offset (8 bytes)
+==== Opcode `0x7B`: Nanoseconds @ Offset (9 bytes)
 [source]
 ----
-+=========+=========+=========+=========+=========+=========+=========+=========+
-|YYYY:YYYM|MMMD:DDDD|HHHH:Hmmm|mmmo:oooo|ooss:ssss|ffff:ffff|ffff:ffff|ffff:----|
-+=========+=========+=========+=========+=========+=========+=========+=========+
++=========+=========+=========+=========+=========+=========+=========+=========+=========+
+|MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|oooo:ommm|ssss:ssoo|ffff:ffff|ffff:ffff|ffff:ffff|--ff:ffff|
++=========+=========+=========+=========+=========+=========+=========+=========+=========+
 ----
 
 WARNING: Opcodes `0x7D`, `0x7E`, and `7F` are illegal; they are reserved for future use.
@@ -920,15 +929,15 @@ Unlike the short-form encoding, the long-form encoding reserves:
 
 If the timestamp's length is greater than or equal to `8`, it has fractional seconds that are encoded as a
 `(coefficient, exponent)` pair, similar to a <<decimals, decimal>>. However, it is illegal for the fractional
-seconds value to be greater than or equal to `1.0` or less than `0.0`. For this reason, both the exponent and
-the coefficient are encoded using unsigned types. The included exponent `VarUInt` is implicitly negative, preventing
-the encoding of decimal numbers greater than `1.0`. The coefficient `FixedUInt` is unsigned to prevent the encoding of
-fractional seconds less than `0.0`. Note that validation is still required; namely:
+seconds value to be greater than or equal to `1.0` or less than `0.0`. For this reason, both the coefficient and
+the exponent are encoded using unsigned types. The included coefficient `VarUInt` is unsigned to prevent the encoding of
+fractional seconds less than `0.0`. The exponent `FixedUInt` is implicitly negative, discouraging the encoding of
+decimal numbers greater than `1.0`. Note that validation is still required; namely:
 
 * An exponent value of `0` is illegal, as that would result in a fractional seconds greater than `1.0` (a whole second).
 * If `coefficient * 10^-exponent > 1.0`, that `(coefficient, exponent)` pair is illegal.
 
-If the timestamp's length is `3`, the least significant bit in the final byte (`h`) is a flag
+If the timestamp's length is `3`, the most significant bit in the final byte (`h`) is a flag
 that indicates month (`0`) or day (`1`) precision.
 
 ==== Opcode `0xF7`: Long-form timestamp
@@ -936,7 +945,7 @@ that indicates month (`0`) or day (`1`) precision.
 ----
      1         2         3         4         5         6         7       8         n
 +=========+=========+=========+=========+=========+=========+=========+=======+   +=========+
-|YYYY:YYYY|YYYY:YYMM|MMDD:DDDh|HHHH:mmmm|mmoo:oooo|oooo:ooss|ssss|----|VarUInt|...|FixedUInt|...
+|YYYY:YYYY|MMYY:YYYY|hDDD:DDMM|mmmm:HHHH|oooo:oomm|ssoo:oooo|----|ssss|VarUInt|...|FixedUInt|...
 +=========+=========+=========+=========+=========+=========+=========+=======+   +=========+
 ----
 

--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -73,7 +73,7 @@ as two's complement.
 .Figure {counter:figure}: `_VarInt_` encoding of `_14_`
 [source,%unbreakable]
 ----
-              ┌──── Lowest bit is 1 (`end`), indicating
+              ┌──── Lowest bit is 1 (end), indicating
               │     this is the only byte.
 0 0 0 1 1 1 0 1
 └─────┬─────┘
@@ -83,7 +83,7 @@ as two's complement.
 .Figure {counter:figure}: `_VarInt_` encoding of `_-14_`
 [source,%unbreakable]
 ----
-              ┌──── Lowest bit is 1 (`end`), indicating
+              ┌──── Lowest bit is 1 (end), indicating
               │     this is the only byte.
 1 1 1 0 0 1 0 1
 └─────┬─────┘
@@ -686,7 +686,7 @@ using UTC time. This required applications to perform conversion logic when tran
 *In Ion 1.1, all binary timestamp fields are encoded in local time.*
 
 [[short_form_timestamp]]
-=== Short-form timestamp
+=== Short-form Timestamp
 
 If an opcode has a high nibble of `0x7_`, it represents a short-form timestamp. This encoding focuses on making the
 most common timestamp precisions and ranges the most compact; less common precisions can still be expressed via
@@ -694,190 +694,297 @@ the variable-length <<long_form_timestamp, long form timestamp>> encoding.
 
 Timestamps may be encoded using the short form if they meet all of the following conditions:
 
-* *The year is between 1970 and 2097*. The year subfield is encoded as the number of years since 1970. 7 bits are
+The year is between 1970 and 2097.:: The year subfield is encoded as the number of years since 1970. 7 bits are
 dedicated to representing the biased year, allowing timestamps through the year 2097 to be encoded in this form.
-* *The local offset is either UTC, unknown, or falls between `-14:00` to `+14:00` and is divisible by 15 minutes.* 7
+The local offset is either UTC, unknown, or falls between `-14:00` to `+14:00` and is divisible by 15 minutes.:: 7
 bits are dedicated to representing the local offset as the number of quarter hours from -56 (that is: offset `-14:00`).
 The value `0b1111111` indicates an unknown offset. At the time of this writing (2023-05T),
-link:https://en.wikipedia.org/wiki/List_of_UTC_offsets[all real-world offsets fall between `-12:00` and `+14:00`].
-* *The timestamp's fractional second precision (if present) is either 3 digits (milliseconds), 6 digits (microseconds),
-or 9 digits (nanoseconds).*
+link:https://en.wikipedia.org/wiki/List_of_UTC_offsets[all real-world offsets fall between `-12:00` and `+14:00`
+and are multiples of 15 minutes].
+The fractional seconds are a common precision.::
+The timestamp's fractional second precision (if present) is either 3 digits (milliseconds), 6 digits (microseconds),
+or 9 digits (nanoseconds).
+
+==== Opcodes by precision and offset
+
+Each opcode with a high nibble of `0x7_` indicates a different precision and offset encoding pair.
+
+[cols="^1a,^1a,^1a,.^4a"]
+|===
+|Opcode | Precision | Serialized size in bytes{asterisk} | Offset encoding
+
+|`0x70`
+|Year
+|1
+.3+|Implicitly _Unknown offset_
+
+|`0x71`
+|Month
+|2
+
+|`0x72`
+|Day
+|2
+
+|`0x73`
+|Hour and minutes
+|4
+.5+|1 bit to indicate _UTC_ or _Unknown Offset_
+
+|`0x74`
+|Seconds
+|5
+
+|`0x75`
+|Milliseconds
+|6
+
+|`0x76`
+|Microseconds
+|7
+
+|`0x77`
+|Nanoseconds
+|8
+
+|`0x78`
+|Hour and minutes
+|5
+.5+|7 bits to represent a known offset. +
+ +
+This encoding can also represent _UTC_ and _Unknown Offset_,
+though it is less compact than opcodes `0x73`-`0x77` above.
+
+|`0x79`
+|Seconds
+|5
+
+|`0x7A`
+|Milliseconds
+|7
+
+|`0x7B`
+|Microseconds
+|8
+
+|`0x7C`
+|Nanoseconds
+|9
+
+|`0x7D`
+3.3+^.^|_Reserved_
+|`0x7E`
+|`0x7F`
+|===
+_{asterisk} Serialized size in bytes does not include the opcode._
 
 The following letters to are used to denote bits in each subfield in diagrams that follow. Subfields occur in the same
 order in all encoding variants, and consume the same number of bits, with the exception of the fractional bits, which
 consume only enough bits to represent the fractional precision supported by the opcode being used.
 
-[cols="^1, ^1, 4"]
+[cols="^.^1a, ^.^1a, .^4a"]
 |===
 |Letter code | Number of bits | Subfield
 
-| *Y*
+| `Y`
 | 7
 | Year
 
-| *M*
+| `M`
 | 4
 | Month
 
-| *D*
+| `D`
 | 5
 | Day
 
-| *H*
+| `H`
 | 5
 | Hour
 
-| *m*
+| `m`
 | 6
 | Minute
 
-| *o*
+| `o`
 | 7
 | Offset
 
-| *U*
+| `U`
 | 1
 | Unknown or UTC offset
 
-| *s*
+| `s`
 |6
 | Second
 
-| *f*
+| `f`
 | 10 (ms) +
-20(μs) +
-30(ns) +
+20 (μs) +
+30 (ns) +
 | Fractional second
 
-| *-*
+| `-`
 | n/a
 | Unused
 |===
 
-NOTE: Timestamps are encoded in Little Endian byte order. In the diagrams below, the bytes are read from left to right
-(least significant to most significant), while the bits within each byte should be read from right to left. (Again
-least significant to most significant.) +
- +
-While this encoding may complicate human reading, it guarantees that the timestamp's subfields (`year`, `month`,
-etc.) occupy the same bit indexes regardless of how many bytes there are overall. (The last subfield,
+Timestamps are encoded in Little Endian byte order. In the diagrams below, the first byte shows the leading opcode
+in hexadecimal; the trailing bytes show the meaning and layout of their respective bits using the letter codes defined
+in the table above.
+
+[source,%unbreakable]
+----
+  byte 1           byte 2                         byte N
++========+========================+=====+========================+
+| OPCODE | high nibble:low nibble | ... | high nibble:low nibble |
++========+========================+=====+========================+
+----
+
+The bytes are read from left to right (least significant to most significant), while the bits within each byte should be
+read from right to left (also least significant to most significant.)
+
+NOTE: While this encoding may complicate human reading, it guarantees that the timestamp's subfields (`year`, `month`,
+etc.) occupy the same bit contiguous indexes regardless of how many bytes there are overall. (The last subfield,
 `fractional_seconds`, always begins at the same bit index when present, but can vary in length according to the
-precision.) This allows processors to read the Little-Endian bytes into an integer and then mask the appropriate
-bit ranges to access the subfields.
+precision.) This arrangement allows processors to read the Little-Endian bytes into an integer and then mask the
+appropriate bit ranges to access the subfields.
 
-==== Opcode `0x70`: Year (1 byte)
-[source]
+.Figure {counter:figure}: Encoding of a timestamp with year precision
+[source,%unbreakable]
 ----
-+=========+
-|-YYY:YYYY|
-+=========+
-----
-
-==== Opcode `0x71`: Month (2 bytes)
-[source]
-----
-+=========+=========+
-|MYYY:YYYY|----:-MMM|
-+=========+=========+
+            1
++======+=========+
+| 0x70 |-YYY:YYYY|
++======+=========+
 ----
 
-==== Opcode `0x72`: Day (2 bytes)
-[source]
+.Figure {counter:figure}: Encoding of a timestamp with month precision
+[source,%unbreakable]
 ----
-+=========+=========+
-|MYYY:YYYY|DDDD:DMMM|
-+=========+=========+
-----
-
-==== Opcode `0x73`: Hour+Minutes @ UTC or Unknown (4 bytes)
-
-NOTE: Each encoding for a precision greater than or equal to `Hour+Minutes` comes in two flavors: one that uses a single
-bit (`U`) to indicate UTC versus Unknown offset, and another that uses 7 bits (`o`) to encode the number of quarter-hours
-offset from `-14:00`.
-
-[source]
-----
-+=========+=========+=========+=========+
-|MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|----:Ummm|
-+=========+=========+=========+=========+
+            1         2
++======+=========+=========+
+| 0x71 |MYYY:YYYY|----:-MMM|
++======+=========+=========+
 ----
 
-==== Opcode `0x74`: Hour+Minutes @ Offset (5 bytes)
-[source]
+.Figure {counter:figure}: Encoding of a timestamp with day precision
+[source,%unbreakable]
+----
+    1       2         3
++======+=========+=========+
+| 0x72 |MYYY:YYYY|DDDD:DMMM|
++======+=========+=========+
 ----
 
-+=========+=========+=========+=========+=========+
-|MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|oooo:ommm|----:--oo|
-+=========+=========+=========+=========+=========+
+.Figure {counter:figure}: Encoding of a timestamp with hour-and-minutes precision at UTC or unknown offset
+[source,%unbreakable]
+----
+            1         2         3         4
++======+=========+=========+=========+=========+
+| 0x73 |MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|----:Ummm|
++======+=========+=========+=========+=========+
 ----
 
-==== Opcode `0x75`: Seconds @ UTC or Unknown (5 bytes)
-[source]
-----
-+=========+=========+=========+=========+=========+
-|MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|ssss:Ummm|----:--ss|
-+=========+=========+=========+=========+=========+
+.Figure {counter:figure}: Encoding of a timestamp with seconds precision at UTC or unknown offset
+[source,%unbreakable]
 ----
 
-==== Opcode `0x76`: Seconds @ Offset (5 bytes)
-[source]
-----
-+=========+=========+=========+=========+=========+
-|MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|oooo:ommm|ssss:ssoo|
-+=========+=========+=========+=========+=========+
+            1         2         3         4         5
++======+=========+=========+=========+=========+=========+
+| 0x74 |MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|ssss:Ummm|----:--ss|
++======+=========+=========+=========+=========+=========+
 ----
 
-==== Opcode `0x77`: Milliseconds @ UTC or Unknown (6 bytes)
-[source]
+.Figure {counter:figure}: Encoding of a timestamp with milliseconds precision at UTC or unknown offset
+[source,%unbreakable]
 ----
-+=========+=========+=========+=========+=========+=========+
-|MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|ssss:Ummm|ffff:ffss|----:ffff|
-+=========+=========+=========+=========+=========+=========+
-----
-
-==== Opcode `0x78`: Milliseconds @ Offset (7 bytes)
-[source]
-----
-+=========+=========+=========+=========+=========+=========+=========+
-|MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|oooo:ommm|ssss:ssoo|ffff:ffff|----:--ff|
-+=========+=========+=========+=========+=========+=========+=========+
+            1         2         3         4         5         6
++======+=========+=========+=========+=========+=========+=========+
+| 0x75 |MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|ssss:Ummm|ffff:ffss|----:ffff|
++======+=========+=========+=========+=========+=========+=========+
 ----
 
-==== Opcode `0x79`: Microseconds @ UTC or Unknown (7 bytes)
-[source]
+.Figure {counter:figure}: Encoding of a timestamp with microseconds precision at UTC or unknown offset
+[source,%unbreakable]
 ----
-+=========+=========+=========+=========+=========+=========+=========+
-|MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|ssss:Ummm|ffff:ffss|ffff:ffff|--ff:ffff|
-+=========+=========+=========+=========+=========+=========+=========+
-----
-
-==== Opcode `0x7A`: Microseconds @ Offset (8 bytes)
-[source]
-----
-+=========+=========+=========+=========+=========+=========+=========+=========+
-|MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|oooo:ommm|ssss:ssoo|ffff:ffff|ffff:ffff|----:ffff|
-+=========+=========+=========+=========+=========+=========+=========+=========+
+            1         2         3         4         5         6         7
++======+=========+=========+=========+=========+=========+=========+=========+
+| 0x76 |MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|ssss:Ummm|ffff:ffss|ffff:ffff|--ff:ffff|
++======+=========+=========+=========+=========+=========+=========+=========+
 ----
 
-==== Opcode `0x7B`: Nanoseconds @ UTC or Unknown (8 bytes)
-[source]
+.Figure {counter:figure}: Encoding of a timestamp with nanoseconds precision at UTC or unknown offset
+[source,%unbreakable]
 ----
-+=========+=========+=========+=========+=========+=========+=========+=========+
-|MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|ssss:Ummm|ffff:ffss|ffff:ffff|ffff:ffff|ffff:ffff|
-+=========+=========+=========+=========+=========+=========+=========+=========+
+            1         2         3         4         5         6         7         8
++======+=========+=========+=========+=========+=========+=========+=========+=========+
+| 0x77 |MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|ssss:Ummm|ffff:ffss|ffff:ffff|ffff:ffff|ffff:ffff|
++======+=========+=========+=========+=========+=========+=========+=========+=========+
 ----
 
-==== Opcode `0x7B`: Nanoseconds @ Offset (9 bytes)
-[source]
+.Figure {counter:figure}: Encoding of a timestamp with hour-and-minutes precision at known offset
+[source,%unbreakable]
 ----
-+=========+=========+=========+=========+=========+=========+=========+=========+=========+
-|MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|oooo:ommm|ssss:ssoo|ffff:ffff|ffff:ffff|ffff:ffff|--ff:ffff|
-+=========+=========+=========+=========+=========+=========+=========+=========+=========+
+
+            1         2         3         4         5
++======+=========+=========+=========+=========+=========+
+| 0x78 |MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|oooo:ommm|----:--oo|
++======+=========+=========+=========+=========+=========+
+----
+
+.Figure {counter:figure}: Encoding of a timestamp with seconds precision at known offset
+[source,%unbreakable]
+----
+            1         2         3         4         5
++======+=========+=========+=========+=========+=========+
+| 0x79 |MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|oooo:ommm|ssss:ssoo|
++======+=========+=========+=========+=========+=========+
+----
+
+.Figure {counter:figure}: Encoding of a timestamp with milliseconds precision at known offset
+[source,%unbreakable]
+----
+            1       2         3         4         5         6         7
++======+=========+=========+=========+=========+=========+=========+=========+
+| 0x7A |MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|oooo:ommm|ssss:ssoo|ffff:ffff|----:--ff|
++======+=========+=========+=========+=========+=========+=========+=========+
+----
+
+.Figure {counter:figure}: Encoding of a timestamp with microseconds precision at known offset
+[source,%unbreakable]
+----
+            1         2         3         4         5         6         7         8
++======+=========+=========+=========+=========+=========+=========+=========+=========+
+| 0x7B |MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|oooo:ommm|ssss:ssoo|ffff:ffff|ffff:ffff|----:ffff|
++======+=========+=========+=========+=========+=========+=========+=========+=========+
+----
+
+.Figure {counter:figure}: Encoding of a timestamp with nanoseconds precision at known offset
+[source,%unbreakable]
+----
+            1         2         3         4
++======+=========+=========+=========+=========+
+| 0x7C |MYYY:YYYY|DDDD:DMMM|mmmH:HHHH|oooo:ommm|
++======+=========+=========+=========+=========+
+
+           5         6         7         8
+       +=========+=========+=========+=========+
+       |ssss:ssoo|ffff:ffff|ffff:ffff|ffff:ffff|
+       +=========+=========+=========+=========+
+
+           9
+       +=========+
+       |--ff:ffff|
+       +=========+
+
+
 ----
 
 WARNING: Opcodes `0x7D`, `0x7E`, and `7F` are illegal; they are reserved for future use.
 
 [[long_form_timestamp]]
-=== Long-form timestamp
+=== Long-form Timestamp
 
 Unlike the <<short_form_timestamp, Short-form timestamp encoding>>, which is limited to encoding
 timestamps in the most commonly referenced timestamp ranges and precisions for which it optimizes,
@@ -939,10 +1046,10 @@ decimal numbers greater than `1.0`. Note that validation is still required; name
 If the timestamp's length is `3`, the most significant bit in the final byte (`h`) is a flag
 that indicates month (`0`) or day (`1`) precision.
 
-==== Opcode `0xF7`: Long-form timestamp
-[source]
+.Figure {counter:figure}: Encoding of the body of a long-form timestamp
+[source,%unbreakable]
 ----
-     1         2         3         4         5         6         7       8         n
+     1         2         3         4         5         6         7         8           n
 +=========+=========+=========+=========+=========+=========+=========+=======+   +=========+
 |YYYY:YYYY|MMYY:YYYY|hDDD:DDMM|mmmm:HHHH|oooo:oomm|ssoo:oooo|----|ssss|VarUInt|...|FixedUInt|...
 +=========+=========+=========+=========+=========+=========+=========+=======+   +=========+

--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -1,5 +1,3 @@
-:toc:
-
 [[encoding_primitives]]
 == Encoding Primitives
 

--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -7,7 +7,7 @@
 A variable-length unsigned integer.
 
 The bytes of a ``VarUInt``s are written in
-link:https://en.wikipedia.org/wiki/Endianness:[little-endian byte order]. This means that the first byte will contain
+link:https://en.wikipedia.org/wiki/Endianness:[little-endian byte order]. This means that the first bytes will contain
 the ``VarUInt``'s least significant bits.
 
 The least significant bits in the `VarUInt` indicate the number of bytes that were used to encode the integer.

--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -631,13 +631,14 @@ double-precision 3.141592653589793
 If an opcode has a high nibble of `0x6_`, it represents a decimal. Low nibble values `0x_E` and below indicate
 the number of trailing bytes used to encode the decimal.
 
-The body of the decimal is encoded as a <<varint, `VarInt`>> representing its exponent, followed by a `FixedInt`
-representing its coefficient. The width of the coefficient is the total length of the decimal encoding minus the length
-of the exponent. It is possible for the coefficient to have a width of zero, indicating a coefficient of `0`.
+The body of the decimal is encoded as a <<varint, `VarInt`>> representing its coefficient, followed by a `FixedInt`
+representing its exponent. The width of the exponent is the total length of the decimal encoding minus the length
+of the coefficient. It is possible for the exponent to have a width of zero, indicating an exponent of `0`.
 
 Decimal values that require more than 14 bytes can be encoded using the variable-length decimal opcode: `0xF6`.
 
-A decimal with a coefficient of `-0` (which cannot be encoded in a `VarInt`) is encoded using opcode `6F`.
+A decimal with a coefficient of `-0` (which cannot be encoded as a `VarInt`) is encoded using opcode `6F`.
+The opcode is followed by a `VarUInt` representing the byte length and a `FixedInt` representing the exponent.
 
 ==== Example encoding of `0d0`
 [source]
@@ -652,11 +653,11 @@ A decimal with a coefficient of `-0` (which cannot be encoded in a `VarInt`) is 
 [source]
 ----
 ┌──── Opcode in range 60-6F indicates a decimal
-│┌─── Low nibble 2 indicates a 2-byte decimal
+│┌─── Low nibble 3 indicates a 3-byte decimal
 ││
-62 fd 7f
-   │  └─── Coefficient: 1-byte FixedInt 127
-   └────── Exponent: VarInt -2
+63 FD 01 FE
+   └─┬─┘ └─── Exponent: 1-byte FixedInt -2
+     └────── Coefficient: VarInt 127
 ----
 
 ==== Example variable-length encoding of `1.27`
@@ -664,10 +665,10 @@ A decimal with a coefficient of `-0` (which cannot be encoded in a `VarInt`) is 
 ----
 ┌──── Opcode F6 indicates a variable-length decimal
 │
-F6 05 fd 7f
-   │  │  └─── Coefficient: 1-byte FixedInt 127
-   │  └────── Exponent: VarInt -2
-   └───────── Decimal length: VarUInt 2
+F6 07 FD 01 FE
+   │  └─┬─┘ └─── Exponent: 1-byte FixedInt -2
+   │    └────── Coefficient: VarInt 127
+   └───────── Decimal length: VarUInt 3
 ----
 
 ==== Example variable-length encoding of `-0d3`

--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -214,6 +214,157 @@ pairs are spliced into the parent struct (TODO: Link)
 An _opcode_ is a 1-byte <<fixeduint, `FixedUInt`>> that tells the reader what the next expression represents and how the
 bytes that follow should be interpreted.
 
+=== Overview table
+
+The meanings of each opcode are organized loosely by their high and low nibbles.
+
+[cols="^.^1a,^.^1a,3a"]
+|===
+|High nibble | Low nibble | Meaning
+
+|`0x0_` to `0x3_`
+| `*`
+|Single-byte macro invocations
+
+|`0x4_`
+| `*`
+|Multibyte macro invocations
+
+.4+|`0x5_`
+| `0`-`8`
+|Integers
+
+|`9`
+<|Reserved
+
+|`A`-`D`
+<|Floats
+
+|`E`-`F`
+<|Booleans
+
+|`0x6_`
+|`*`
+|Decimals
+
+|`0x7_`
+|`*`
+|Timestamps
+
+|`0x8_`
+|`*`
+|Strings
+
+|`0x9_`
+|`*`
+|Symbols with inline text
+
+|`0xA_`
+|`*`
+|Lists
+
+|`0xB_`
+|`*`
+|S-expressions
+
+.3+|`0xC_`
+|`0`
+|Empty struct
+
+|`1`
+<|Reserved
+
+|`2`-`F`
+<|Structs with symbol address field names
+
+.2+|`0xD_`
+|`0`-`1`
+|Reserved
+
+|`2`-`F`
+<|Structs with `VarSym` field names
+
+.9+|`0xE_`
+|`0`
+|Ion version marker
+
+|`1`-`3`
+<|Symbols with symbol table text
+
+|`4`-`6`
+<|Annotations with symbol table text
+
+|`7`-`9`
+<|Annotations with `VarSym` text
+
+|`A`
+<|`null.null`
+
+|`B`
+<|Typed nulls
+
+|`C`-`D`
+<|NOP
+
+|`E`
+<|Reserved
+
+|`F`
+<|System macro invocation
+
+.16+|`0xF_`
+|`0`
+|Delimited container end
+
+|`1`
+<|Delimited list start
+
+|`2`
+<|Delimited S-expression start
+
+|`3`
+<|Delimited struct with `VarSym` field names start
+
+|`4`
+<|Reserved
+
+|`5`
+<|Variable length integer
+
+|`6`
+<|Variable length decimal
+
+|`7`
+<|Variable length, long-form timestamp
+
+|`8`
+<|Variable length string
+
+|`9`
+<|Variable length symbol encoded as `VarSym`
+
+|`A`
+<|Variable length list
+
+|`B`
+<|Variable length S-expression
+
+|`C`
+<|Variable length struct with symbol address field names
+
+|`D`
+<|Variable length struct with `VarSym` field names
+
+|`E`
+<|Reserved
+
+|`F`
+<|Variable length prefixed macro invocation
+
+|===
+
+
+
 [[single_byte_macro_invocations]]
 === Single-byte macro invocations
 
@@ -373,7 +524,8 @@ Opcodes in the range `0x50` to `0x58` represent an integer. The opcode is follow
 represents the integer value. The low nibble of the opcode (`0x_0` to `0x_8`) indicates the size of the `FixedInt`.
 Opcode `0x50` represents integer `0`; no more bytes follow.
 
-Integers that require more than 8 bytes are encoded using the variable-length integer opcode `0xF4`, followed by a
+Integers that require more than 8 bytes are encoded using the variable-length integer opcode `0xF5`,
+followed by a
 <<varuint, VarUInt>> indicating how many bytes of representation data follow.
 
 ==== Example encoding of `0`
@@ -409,10 +561,10 @@ FixedInt -944
 ==== Example variable-length encoding of `-944`
 [source]
 ----
-┌──── Opcode F4 indicates a variable-length integer, VarUInt length follows
+┌──── Opcode F5 indicates a variable-length integer, VarUInt length follows
 │   ┌─── VarUInt 2; a 2-byte FixedInt follows
 │   │    that two bytes follow.
-F4 05 50 fc
+F5 05 50 fc
       └─┬─┘
    FixedInt -944
 ----
@@ -789,19 +941,112 @@ that indicates month (`0`) or day (`1`) precision.
 +=========+=========+=========+=========+=========+=========+=========+=======+   +=========+
 ----
 
-// TODO: The remaining sections (and others) will be added/completed in a follow-on PR
-
 [[text]]
 == Text
 
 [[strings]]
 === Strings
 
+If the high nibble of the opcode is `0x8_`, it represents a string. The low nibble of the opcode
+indicates how many UTF-8 bytes follow. Opcode 0x80 represents a string with empty text ("").
+
+Strings longer than 15 bytes can be encoded with the `F8` opcode, which takes a <<varuint, `VarUInt`>>-encoded length
+after the opcode.
+
+==== Example encoding of the empty string (`""`)
+[source]
+----
+┌──── Opcode in range 80-8F indicates a string
+│┌─── Low nibble 0 indicates that no UTF-8 bytes follow
+80
+----
+
+==== Example encoding of a 14-byte string
+[source]
+----
+┌──── Opcode in range 80-8F indicates a string
+│┌─── Low nibble E indicates that 14 UTF-8 bytes follow
+││  f  o  u  r  t  e  e  n     b  y  t  e  s
+8E 66 6f 75 72 74 65 65 6e 20 62 79 74 65 73
+   └──────────────────┬────────────────────┘
+                 UTF-8 bytes
+----
+
+==== Example encoding of a 24-byte string
+[source]
+----
+┌──── Opcode F8 indicates a variable-length string
+│  ┌─── Length: VarUInt 24
+│  │   v  a  r  i  a  b  l  e     l  e  n  g  t  h     e  n  c  o  d  i  n  g
+F8 31 76 61 72 69 61 62 6c 65 20 6c 65 6e 67 74 68 20 65 6e 63 6f 64 69 6e 67
+      └────────────────────────────────┬────────────────────────────────────┘
+                                  UTF-8 bytes
+----
+
 [[symbols_with_inline_text]]
 === Symbols with inline text
 
+==== Example encoding of a symbol with empty text (`''`)
+[source]
+----
+┌──── Opcode in range 90-9F indicates a symbol with inline text
+│┌─── Low nibble 0 indicates that no UTF-8 bytes follow
+90
+----
+
+==== Example encoding of a symbol with 14 bytes of inline text
+[source]
+----
+┌──── Opcode in range 90-9F indicates a symbol with inline text
+│┌─── Low nibble E indicates that 14 UTF-8 bytes follow
+││  f  o  u  r  t  e  e  n     b  y  t  e  s
+9E 66 6f 75 72 74 65 65 6e 20 62 79 74 65 73
+   └──────────────────┬────────────────────┘
+                 UTF-8 bytes
+----
+
+==== Example encoding of a symbol with 24 bytes of inline text
+[source]
+----
+┌──── Opcode F9 indicates a variable-length symbol with inline text
+│  ┌─── Length: VarUInt 24
+│  │   v  a  r  i  a  b  l  e     l  e  n  g  t  h     e  n  c  o  d  i  n  g
+F9 31 76 61 72 69 61 62 6c 65 20 6c 65 6e 67 74 68 20 65 6e 63 6f 64 69 6e 67
+      └────────────────────────────────┬────────────────────────────────────┘
+                                  UTF-8 bytes
+----
+
 [[symbols_with_symbol_table_addresses]]
-=== Symbols with symbol table text
+=== Symbols with text in the symbol table
+
+Symbol values whose text can be found in the local symbol table are encoded using opcodes `0xE1` through `0xE3`:
+
+* `0xE1` represents a symbol whose address in the symbol table (aka its symbol ID) is a 1-byte
+<<fixeduint, `FixedUInt`>> that follows the opcode.
+* `0xE2` represents a symbol whose address in the symbol table is a 2-byte <<fixeduint, `FixedUInt`>> that follows
+the opcode.
+* `0xE3` represents a symbol whose address in the symbol table is a <<varuint,`VarUInt`>> that follows the opcode.
+
+Writers MUST encode a symbol address in the smallest number of bytes possible. For each opcode above, the symbol
+address that is decoded is biased by the number of addresses that can be encoded in fewer bytes.
+
+[cols="^1,1,1"]
+|===
+|Opcode |Symbol address range |Bias
+
+|*0xE1*
+|0 to 255
+|0
+
+|*0xE2*
+|256 to 16,640
+|256
+
+|*0xE3*
+|16,641 to infinity
+|16,641
+|===
+
 
 [[binary_data]]
 == Binary data
@@ -811,3 +1056,15 @@ that indicates month (`0`) or day (`1`) precision.
 
 [[clobs]]
 === Clobs
+
+[[containers]]
+== Containers
+
+[[lists]]
+=== Lists
+
+[[s_expressions]]
+=== S-expressions
+
+[[structs]]
+=== Structs

--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -13,9 +13,10 @@ The bytes of a ``VarUInt``s are written in
 link:https://en.wikipedia.org/wiki/Endianness:[Little Endian byte order]. This means that the first byte will contain
 the ``VarUInt``'s least significant bits.
 
-The least significant bits in the `VarUInt` indicate the number of bytes that were used to encode the integer. The number
-of bytes can be found by counting the number of trailing zeros in the first byte(s) and adding one to it. All bits that
-are more significant than the first `1` represent the magnitude of the `VarUInt`.
+The least significant bits in the `VarUInt` indicate the number of bytes that were used to encode the integer.
+If a `VarUInt` is `_N_` bytes long, its `_N-1_` least significant bits will be `0`; a terminal `1` bit will be
+in the next most significant position.
+All bits that are more significant than the terminal `1` represent the magnitude of the `VarUInt`.
 
 ==== Example encoding of VarUInt 14 ====
 [source]
@@ -30,7 +31,7 @@ unsigned int 14
 ==== Example encoding of VarUInt 729 ====
 [source]
 ----
-             ┌──── There's 1 trailing zero, so this
+             ┌──── There's 1 zero in the least significant bits, so this
              │     integer is two bytes wide.
             ┌┴┐
 0 1 1 0 0 1 1 0  0 0 0 0 1 0 1 1
@@ -43,7 +44,7 @@ integer          integer
 ==== Example encoding of VarUInt 21,043 ====
 [source]
 ----
-            ┌───── There are 2 trailing zeros, so this
+            ┌───── There are 2 zeros in the least significant bits, so this
             │      integer is three bytes wide.
           ┌─┴─┐
 1 0 0 1 1 1 0 0  1 0 0 1 0 0 0 1  0 0 0 0 0 0 1 0
@@ -64,9 +65,9 @@ link:https://amazon-ion.github.io/ion-docs/docs/binary.html#varuint-and-varint-f
 A variable-length signed integer.
 
 From an encoding perspective, ``VarInt``s are structurally similar to a `VarUInt` (<<varuint, described above>>). Both
-encode their bytes using Little Endian byte order, and both use the count of trailing zero bits to indicate how many
-bytes were used to encode the integer. They differ in the _interpretation_ of their bits; while a ``VarUInt``'s bits
-are unsigned, a ``VarInt``'s bits are encoded using
+encode their bytes using Little Endian byte order, and both use the count of least-significant zero bits to indicate
+how many bytes were used to encode the integer. They differ in the _interpretation_ of their bits; while a
+``VarUInt``'s bits are unsigned, a ``VarInt``'s bits are encoded using
 link:https://en.wikipedia.org/wiki/Two%27s_complement[two's complement notation].
 
 TIP: An implementation could choose to read a `VarInt` by instead reading a `VarUInt` and then reinterpreting its bits
@@ -77,7 +78,7 @@ as two's complement.
 ----
               ┌──── Lowest bit is 1 (`end`), indicating
               │     this is the only byte.
-0 0 0 0 1 1 1 1
+0 0 0 1 1 1 0 1
 └─────┬─────┘
  2's comp. 14
 ----
@@ -95,7 +96,7 @@ as two's complement.
 ==== Example encoding of VarInt 729 ====
 [source]
 ----
-             ┌──── There's 1 trailing zero, so this
+             ┌──── There's 1 zero in the least significant bits, so this
              │     integer is two bytes wide.
             ┌┴┐
 0 1 1 0 0 1 1 0  0 0 0 0 1 0 1 1
@@ -108,7 +109,7 @@ comp. integer    comp. integer
 ==== Example encoding of VarInt -729 ====
 [source]
 ----
-             ┌──── There's 1 trailing zero, so this
+             ┌──── There's 1 zero in the least significant bits, so this
              │     integer is two bytes wide.
             ┌┴┐
 1 0 0 1 1 1 1 0  1 1 1 1 0 1 0 0
@@ -166,11 +167,11 @@ represent the symbol’s text.
 * *exactly zero*, another byte follows that is an <<opcodes, opcode>>. The `VarSym` parser is not responsible for
 evaluating this opcode, only returning it—the caller will decide whether the opcode is legal in the current context.
 Example usages of the opcode include:
-** Representing SID `$0` as `0x70`
-** Representing the empty string (`""`) as `0x80`
+** Representing SID `$0` as `0x70`. (See: <<strings, Strings>>)
+** Representing the empty string (`""`) as `0x80`. (See: <<symbols_with_inline_text, Symbols with inline text>>)
 ** When used to encode a struct field name, the opcode can invoke a macro that will evaluate to a struct whose key/value
 pairs are spliced into the parent struct (TODO: Link)
-** In a delimited struct, terminating the sequence of (name, value) pairs with `0xAD`. (TODO: Link)
+** In a <<delimited_structs, delimited struct>>, terminating the sequence of `(field name, value)` pairs with `0xF0`.
 
 ==== Example encoding of a `VarSym` with symbol ID `$10` ====
 [source]
@@ -223,16 +224,16 @@ The meanings of each opcode are organized loosely by their high and low nibbles.
 |High nibble | Low nibble | Meaning
 
 |`0x0_` to `0x3_`
-| `*`
+|`*`
 |Single-byte macro invocations
 
 |`0x4_`
-| `*`
+|`*`
 |Multibyte macro invocations
 
 .4+|`0x5_`
-| `0`-`8`
-|Integers
+|`0`-`8`
+|Integers up to 8 bytes wide
 
 |`9`
 <|Reserved
@@ -474,8 +475,8 @@ Biased value  : 1,211
 [source]
 ----
 
-                              ┌─── The address VarUInt ends in `10`; the trailing
-                              │    zero indicates that one more VarUInt byte follows.
+                              ┌─── The address VarUInt ends in `10`; the zero in the least significant
+                              │    bits indicates that one more VarUInt byte follows.
                              ┌┴┐
 0 1 0 0 0 0 0 0  1 0 1 0 0 1 1 0  0 1 0 0 0 1 0 1
 └──┬──┘ └──┬──┘  └──────┬──────┘  └──────┬──────┘
@@ -492,23 +493,20 @@ Decoded value : 71,312
 Biased value  : 71,376
 ----
 
-NOTE: From this point on in the document, example encodings are given in hexidecimal notation.
+NOTE: From this point on in the document, example encodings are given in hexadecimal notation.
 
 [[booleans]]
 == Booleans
 
 `0x5E` represents boolean `true`, while `0x5F` represents boolean `false`.
 
-// XXX: Structurally, these examples should be at depth 3. However, all other example sections in the doc
-//      are at heading depth 4, which keeps them out of the TOC. These are also at depth 4 for consistency.
-
-==== Example encoding of `true`
+=== Example encoding of `true`
 [source]
 ----
 5e
 ----
 
-==== Example encoding of `false`
+=== Example encoding of `false`
 [source]
 ----
 5f
@@ -563,7 +561,7 @@ FixedInt -944
 ----
 ┌──── Opcode F5 indicates a variable-length integer, VarUInt length follows
 │   ┌─── VarUInt 2; a 2-byte FixedInt follows
-│   │    that two bytes follow.
+│   │
 F5 05 50 fc
       └─┬─┘
    FixedInt -944
@@ -1030,7 +1028,7 @@ the opcode.
 Writers MUST encode a symbol address in the smallest number of bytes possible. For each opcode above, the symbol
 address that is decoded is biased by the number of addresses that can be encoded in fewer bytes.
 
-[cols="^1a,1a,1a"]
+[cols="^1a,4a,4a"]
 |===
 |Opcode |Symbol address range |Bias
 
@@ -1039,12 +1037,12 @@ address that is decoded is biased by the number of addresses that can be encoded
 |0
 
 |`0xE2`
-|256 to 16,640
+|256 to 65,791
 |256
 
 |`0xE3`
-|16,641 to infinity
-|16,641
+|65,792 to infinity
+|65,792
 |===
 
 [[binary_data]]
@@ -1327,7 +1325,8 @@ An opcode with a high nibble of `0xD_` indicates a struct with <<varsym, `VarSym
 nibble of the opcode indicates how many bytes were used to encode all of its nested `(field name, value)`
 pairs.
 
-WARNING: Empty structs MUST be written using `0xC0`. `0xD0` is a reserved opcode.
+WARNING: Empty length-prefixed structs MUST be written using `0xC0`. `0xD0` is a reserved opcode. Empty
+<<delimited_structs, delimited structs>> have their own encoding.
 
 If the struct's encoded byte-length is too large to be encoded in a nibble, writers may use the `0xFD` opcode
 to write a variable-length struct with <<varsym, `VarSym`>> field names. The `0xFD` opcode is followed by a
@@ -1349,15 +1348,27 @@ D9 FD 66 6F 6F 51 01 17 91 02
        bytes
 ----
 
-// TODO: Demonstrate splicing macro values into the struct via VarSym escape code `0x00`.
+TODO: Demonstrate splicing macro values into the struct via VarSym escape code `0x00`.
 
 [[delimited_structs]]
 ==== Delimited structs
 
-Opcode `0xF3` indicates the beginning of a delimited struct with `VarSym` field names,
+Opcode `0xF3` indicates the beginning of a delimited struct with <<varsym, `VarSym`>> field names,
 while opcode `0xF0` closes the most recently opened delimited container that has not yet been closed.
 
-NOTE: There is no delimited encoding for structs with symbol address field names.
+NOTE: While length-prefixed structs can choose between <<structs_with_symbol_address_field_names, structs with
+symbol address field names>> and <<structs_with_varsym_field_names, structs with `VarSym` field names>>,
+delimited structs always use `VarSym`-encoded field names.
+
+===== Example encoding of the empty struct (`{}`)
+[source]
+----
+┌─── Opcode 0xF3 indicates the beginning of a delimited struct with `VarSym` field names.│
+│  ┌─── VarSym escape code 0x00: an opcode follows
+│  │  ┌─── Opcode 0xF0 indicates the end of the most
+│  │  │    recently opened delimited container
+F3 00 F0
+----
 
 ===== Example encoding of `{"foo": 1, $11: 2}`
 [source]
@@ -1365,10 +1376,10 @@ NOTE: There is no delimited encoding for structs with symbol address field names
 ┌─── Opcode 0xF3 indicates the beginning of a delimited struct with `VarSym` field names.
 │
 │  ┌─ VarSym -3      ┌─ VarSym: 11 ($11)
-│  │                 │
-│  │                 │         ┌─ Opcode 0xF0 indicates the end of the most
-│  │   f  o  o       │         │  recently opened delimited container
-F3 FD 66 6F 6F 51 01 17 91 02 F0
+│  │                 │        ┌─── VarSym escape code 0x00: an opcode follows
+│  │                 │        │  ┌─── Opcode 0xF0 indicates the end of the most
+│  │   f  o  o       │        │  │    recently opened delimited container
+F3 FD 66 6F 6F 51 01 17 91 02 00 F0
       └──┬───┘ └─┬─┘    └─┬─┘
       3 UTF-8    1        2
        bytes
@@ -1455,9 +1466,6 @@ It is illegal for an annotations sequence to appear before any of the following:
 // TODO: Links
 * An E-expression (that is: a macro invocation). To add annotations to a macro invocation, see the
 `annotate` macro.
-
-If an annotations sequence appears before one or more additional annotations sequences, the sequences
-are concatenated.
 
 [[annotations_with_symbol_addresses]]
 ==== Annotations with symbol addresses

--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -152,7 +152,7 @@ comp. integer    integer          integer
 [[varsym]]
 === `VarSym`
 
-A variable-length symbol whose UTF-8 bytes can be inline, found in the symbol table, or derived from a macro
+A variable-length symbol token whose UTF-8 bytes can be inline, found in the symbol table, or derived from a macro
 expansion.
 
 A `VarSym` begins with a <<varint,`VarInt`>>; once this integer has been read, we can evaluate it to determine how to proceed. If the VarInt is:
@@ -287,10 +287,10 @@ The meanings of each opcode are organized loosely by their high and low nibbles.
 |Ion version marker
 
 |`1`-`3`
-<|Symbols with symbol table text
+<|Symbols with symbol address
 
 |`4`-`6`
-<|Annotations with symbol table text
+<|Annotations with symbol address
 
 |`7`-`9`
 <|Annotations with `VarSym` text
@@ -1133,8 +1133,8 @@ F9 31 76 61 72 69 61 62 6C 65 20 6C 65 6E 67 74 68 20 65 6E 63 6f 64 69 6E 67
                                   UTF-8 bytes
 ----
 
-[[symbols_with_symbol_address_text]]
-=== Symbols With Symbol Address Text
+[[symbols_with_symbol_address]]
+=== Symbols With Symbol Address
 
 Symbol values whose text can be found in the local symbol table are encoded using opcodes `0xE1` through `0xE3`:
 

--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -680,7 +680,7 @@ The opcode is followed by a `FlexInt` representing the exponent.
 ┌──── Opcode in range 60-6F indicates a decimal
 │┌─── Low nibble 1 indicates a 1-byte decimal
 ││
-60 0F
+61 0F
    └─── Coefficient: FlexInt 7; no more bytes follow, so exponent is implicitly 0
 ----
 

--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -1,0 +1,803 @@
+= Binary Encoding
+:toc:
+
+[[encoding_primitives]]
+== Encoding primitives
+
+[[varuint]]
+=== `VarUInt`
+
+A variable-length unsigned integer.
+
+The bytes of a ``VarUInt``s are written in
+link:https://en.wikipedia.org/wiki/Endianness:[Little Endian byte order]. This means that the first byte will contain
+the ``VarUInt``'s least significant bits.
+
+The least significant bits in the `VarUInt` indicate the number of bytes that were used to encode the integer. The number
+of bytes can be found by counting the number of trailing zeros in the first byte(s) and adding one to it. All bits that
+are more significant than the first `1` represent the magnitude of the `VarUInt`.
+
+==== Example encoding of VarUInt 14 ====
+[source]
+----
+              ┌──── Lowest bit is 1 (`end`), indicating
+              │     this is the only byte.
+0 0 0 1 1 1 0 1
+└─────┬─────┘
+unsigned int 14
+----
+
+==== Example encoding of VarUInt 729 ====
+[source]
+----
+             ┌──── There's 1 trailing zero, so this
+             │     integer is two bytes wide.
+            ┌┴┐
+0 1 1 0 0 1 1 0  0 0 0 0 1 0 1 1
+└────┬────┘      └──────┬──────┘
+lowest 6 bits    highest 8 bits
+of the unsigned  of the unsigned
+integer          integer
+----
+
+==== Example encoding of VarUInt 21,043 ====
+[source]
+----
+            ┌───── There are 2 trailing zeros, so this
+            │      integer is three bytes wide.
+          ┌─┴─┐
+1 0 0 1 1 1 0 0  1 0 0 1 0 0 0 1  0 0 0 0 0 0 1 0
+└───┬───┘        └──────┬──────┘  └──────┬──────┘
+lowest 6 bits    next 8 bits of   highest 8 bits
+of the unsigned  the unsigned     of the unsigned
+integer          integer          integer
+----
+
+NOTE: Ion 1.0 uses link:https://en.wikipedia.org/wiki/Endianness[Big Endian byte order] and indicates the width of the
+integer by having
+link:https://amazon-ion.github.io/ion-docs/docs/binary.html#varuint-and-varint-fields[an `end` flag bit in the highest
+ bit of each byte].
+
+[[varint]]
+=== `VarInt`
+
+A variable-length signed integer.
+
+From an encoding perspective, ``VarInt``s are structurally similar to a `VarUInt` (<<varuint, described above>>). Both
+encode their bytes using Little Endian byte order, and both use the count of trailing zero bits to indicate how many
+bytes were used to encode the integer. They differ in the _interpretation_ of their bits; while a ``VarUInt``'s bits
+are unsigned, a ``VarInt``'s bits are encoded using
+link:https://en.wikipedia.org/wiki/Two%27s_complement[two's complement notation].
+
+TIP: An implementation could choose to read a `VarInt` by instead reading a `VarUInt` and then reinterpreting its bits
+as two's complement.
+
+==== Example encoding of VarInt 14 ====
+[source]
+----
+              ┌──── Lowest bit is 1 (`end`), indicating
+              │     this is the only byte.
+0 0 0 0 1 1 1 1
+└─────┬─────┘
+ 2's comp. 14
+----
+
+==== Example encoding of VarInt -14 ====
+[source]
+----
+              ┌──── Lowest bit is 1 (`end`), indicating
+              │     this is the only byte.
+1 1 1 0 0 1 0 1
+└─────┬─────┘
+ 2's comp. -14
+----
+
+==== Example encoding of VarInt 729 ====
+[source]
+----
+             ┌──── There's 1 trailing zero, so this
+             │     integer is two bytes wide.
+            ┌┴┐
+0 1 1 0 0 1 1 0  0 0 0 0 1 0 1 1
+└────┬────┘      └──────┬──────┘
+lowest 6 bits    highest 8 bits
+of the 2's       of the 2's
+comp. integer    comp. integer
+----
+
+==== Example encoding of VarInt -729 ====
+[source]
+----
+             ┌──── There's 1 trailing zero, so this
+             │     integer is two bytes wide.
+            ┌┴┐
+1 0 0 1 1 1 1 0  1 1 1 1 0 1 0 0
+└────┬────┘      └──────┬──────┘
+lowest 6 bits    highest 8 bits
+of the 2's       of the 2's
+comp. integer    comp. integer
+----
+
+[[fixeduint]]
+=== `FixedUInt`
+
+A fixed-width, little-endian, unsigned integer whose length is inferred from the context in which it appears.
+
+==== Example encoding of FixedUInt 3,954,261 ====
+[source]
+----
+
+0 1 0 1 0 1 0 1  0 1 0 1 0 1 1 0  0 0 1 1 1 1 0 0
+└──────┬──────┘  └──────┬──────┘  └──────┬──────┘
+lowest 8 bits    next 8 bits of   highest 8 bits
+of the unsigned  the unsigned     of the unsigned
+integer          integer          integer
+----
+
+[[fixedint]]
+=== `FixedInt`
+
+A fixed-width, little-endian, signed integer whose length is known from the context in which it appears. Its bytes
+are interpreted as two's complement.
+
+==== Example encoding of FixedInt -3,954,261 ====
+[source]
+----
+
+1 0 1 0 1 0 1 1  1 0 1 0 1 0 0 1  1 1 0 0 0 0 1 1
+└──────┬──────┘  └──────┬──────┘  └──────┬──────┘
+lowest 8 bits    next 8 bits of   highest 8 bits
+of the 2's       the 2's comp.    of the 2's comp.
+comp. integer    integer          integer
+----
+
+[[varsym]]
+=== `VarSym`
+
+A variable-length symbol whose UTF-8 bytes can be inline, found in the symbol table, or derived from a macro
+expansion.
+
+A `VarSym` begins with a <<varint,`VarInt`>>; once this integer has been read, we can evaluate it to determine how to proceed. If the VarInt is:
+
+* *greater than zero*, it represents a symbol ID. The symbol’s associated text can be found in the local symbol table. No more bytes follow.
+* *less than zero*, its absolute value represents a number of UTF-8 bytes that follow the `VarInt`. These bytes represent the symbol’s text.
+* *exactly zero*, another byte follows that is an <<opcodes, opcode>>. The `VarSym` parser is not responsible for evaluating this opcode, only returning it—the caller will decide whether the opcode is legal in the current context. Example usages of the opcode include:
+** Representing SID `$0` as `0x70`
+** Representing the empty string (`""`) as `0x80`
+** When used to encode a struct field name, the opcode can invoke a macro that will evaluate to a struct whose key/value pairs are spliced into the parent struct (TODO: Link)
+** In a delimited struct, terminating the sequence of (name, value) pairs with `0xAD`. (TODO: Link)
+
+==== Example encoding of a `VarSym` with symbol ID `$10` ====
+[source]
+----
+              ┌─── The leading VarInt ends in a `1`,
+              │    no more VarInt bytes follow.
+              │
+0 0 0 1 0 1 0 1
+└─────┬─────┘
+  2's comp.
+  positive 10
+----
+
+==== Example encoding of a `VarSym` with symbol text `hello` ====
+[source]
+----
+              ┌─── The leading VarInt ends in a `1`,
+              │    no more VarInt bytes follow.
+              │      h         e        l        l        o
+1 1 1 1 0 1 1 1  01101000  01100101 01101100 01101100 01101111
+└─────┬─────┘    └─────────────────────┬─────────────────────┘
+  2's comp.               5-byte UTF-8 encoded "hello"
+  negative 5
+----
+
+==== Example encoding of `''` (symbol with empty text) using an opcode ====
+[source]
+----
+              ┌─── The leading VarInt ends in a `1`,
+              │    no more VarInt bytes follow.
+              │
+0 0 0 0 0 0 0 1  1110000
+└─────┬─────┘    └──┬──┘
+  2's comp.      opcode 0x70:
+  zero           empty symbol
+----
+
+[[opcodes]]
+== Opcodes
+
+An _opcode_ is a 1-byte <<fixeduint, `FixedUInt`>> that tells the reader what the next expression represents and how the
+bytes that follow should be interpreted.
+
+[[single_byte_macro_invocations]]
+=== Single-byte macro invocations
+
+// TODO: link to macros chapter
+
+If the value of the opcode is less than `64` (`0x40`), it represents an invocation of the macro at the corresponding
+__address__—an offset within the local macro table.
+
+==== Example encoding of a single-byte invocation of the macro at address `7`
+[source]
+----
+0 0 0 0 0 1 1 1
+└──────┬──────┘
+  FixedUInt 7
+----
+
+==== Example encoding of an invocation of the macro at address `31`
+[source]
+----
+0 0 0 1 1 1 1 1
+└──────┬──────┘
+  FixedUInt 31
+----
+
+// TODO: Link to macro calling conventions
+
+Note that the opcode alone tells us which macro is being invoked, but it does not supply enough information for the
+reader to parse any arguments that may follow. The parsing of arguments is described in detail in the section _Macro
+calling conventions_.
+
+[[multi_byte_macro_invocations]]
+=== Multibyte macro invocations
+
+While invocations of macro addresses in the range `[0, 63]` can be encoded in a single byte using
+<<single_byte_macro_invocations, single byte macro invocations>>, many applications will benefit from defining more than
+64 macros.
+
+If the high nibble of the opcode is `0x4_`, then the low nibble represents the four least significant bits of the macro
+address. A <<varuint, `VarUInt`>> follows that contains the remaining, more significant bits.
+
+Because the first 64 macro addresses can already be encoded using high nibbles `0` to `3`, the decoded value is biased
+by 64. (That is: the reader must add 64 to the decoded value. If the decoded value is `0`, the macro address that it
+represents is `64`.)
+
+Because the address is encoded using a `VarUInt`, there is no (theoretical) limit to the number of addresses that can
+be invoked. However, larger addresses require more bytes to encode. This following table shows the number of bytes
+needed to encode invocations of macro addresses in various ranges.
+
+|===
+| Address range | Bytes needed | Magnitude bits available
+
+|0 to 63
+|1
+|6
+
+|64 to 2,112
+|2
+|11
+
+|2,113 to 262,208
+|3
+|18
+
+|262,209 to 33,554,432
+|4
+|25
+|===
+
+==== Example encoding of an invocation of the macro at address `131`
+[source]
+----
+                               ┌─── The address VarUInt ends in a `1`,
+                               │    no more VarUInt bytes follow.
+                               │
+0 1 0 0 0 0 1 1  0 0 0 0 1 0 0 1
+└──┬──┘ └──┬──┘  └──────┬──────┘
+   │       │            └──────────── VarUInt containing the 7 most
+   │       └── 4 least significant    significant bits of the macro
+opcode high    bits of the macro      address
+nibble 4       address
+
+Magnitude bits: 0000100_0011
+Decoded value : 67
+Biased value  : 131
+----
+
+==== Example encoding of an invocation of the macro at address `1211`
+[source]
+----
+
+                               ┌─── The address VarUInt ends in a `1`,
+                               │    no more VarUInt bytes follow.
+                               │
+0 1 0 0 1 0 1 1  1 0 0 0 1 1 1 1
+└──┬──┘ └──┬──┘  └──────┬──────┘
+   │       │            └──────────── VarUInt containing the 7 most
+   │       └── 4 least significant    significant bits of the macro
+opcode high    bits of the macro      address
+nibble 4       address
+
+Magnitude bits: 1000111_1011
+Decoded value : 1,147
+Biased value  : 1,211
+----
+
+==== Example encoding of an invocation of the macro at address `71376`
+[source]
+----
+
+                              ┌─── The address VarUInt ends in `10`; the trailing
+                              │    zero indicates that one more VarUInt byte follows.
+                             ┌┴┐
+0 1 0 0 0 0 0 0  1 0 1 0 0 1 1 0  0 1 0 0 0 1 0 1
+└──┬──┘ └──┬──┘  └──────┬──────┘  └──────┬──────┘
+   │       │            │                └──────────── the 8 most significant bits
+   │       │            │                              of the macro address
+   │       │            │
+   │       │            └──────────── VarUInt containing the next 7 most
+   │       └── 4 least significant    significant bits of the macro
+opcode high    bits of the macro      address
+nibble 4       address
+
+Magnitude bits: 01000101_101001_0000
+Decoded value : 71,312
+Biased value  : 71,376
+----
+
+NOTE: From this point on in the document, example encodings are given in hexidecimal notation.
+
+[[booleans]]
+== Booleans
+
+`0x5E` represents boolean `true`, while `0x5F` represents boolean `false`.
+
+// XXX: Structurally, these examples should be at depth 3. However, all other example sections in the doc
+//      are at heading depth 4, which keeps them out of the TOC. These are also at depth 4 for consistency.
+
+==== Example encoding of `true`
+[source]
+----
+5e
+----
+
+==== Example encoding of `false`
+[source]
+----
+5f
+----
+
+[[numbers]]
+== Numbers
+
+[[integers]]
+=== Integers
+
+Opcodes in the range `0x50` to `0x58` represent an integer. The opcode is followed by a <<fixedint, `FixedInt`>> that
+represents the integer value. The low nibble of the opcode (`0x_0` to `0x_8`) indicates the size of the `FixedInt`.
+Opcode `0x50` represents integer `0`; no more bytes follow.
+
+Integers that require more than 8 bytes are encoded using the variable-length integer opcode `0xF4`, followed by a
+<<varuint, VarUInt>> indicating how many bytes of representation data follow.
+
+==== Example encoding of `0`
+[source]
+----
+┌──── Opcode in 50-58 range indicates integer
+│┌─── Low nibble 0 indicates
+││    no more bytes follow.
+50
+----
+
+==== Example encoding of `17`
+[source]
+----
+┌──── Opcode in 50-58 range indicates integer
+│┌─── Low nibble 1 indicates
+││    a single byte follows.
+51 11
+    └── FixedInt 17
+----
+
+==== Example encoding of `-944`
+[source]
+----
+┌──── Opcode in 50-58 range indicates integer
+│┌─── Low nibble 2 indicates
+││    that two bytes follow.
+52 50 fc
+   └─┬─┘
+FixedInt -944
+----
+
+==== Example variable-length encoding of `-944`
+[source]
+----
+┌──── Opcode F4 indicates a variable-length integer, VarUInt length follows
+│   ┌─── VarUInt 2; a 2-byte FixedInt follows
+│   │    that two bytes follow.
+F4 05 50 fc
+      └─┬─┘
+   FixedInt -944
+----
+
+[[floats]]
+=== Floats
+
+Float values are encoded using the IEEE-754 specification, and can be serialized in four sizes:
+
+* 0 bits (0 bytes), representing the value 0e0 and indicated by opcode `0x5A`
+* 16 bits (2 bytes, link:https://en.wikipedia.org/wiki/Half-precision_floating-point_format[half precision]), indicated
+by opcode `0x5B`
+* 32 bits (4 bytes, link:https://en.wikipedia.org/wiki/Single-precision_floating-point_format[single precision]), indicated by opcode `0x5C`
+* 64 bits (8 bytes, link:https://en.wikipedia.org/wiki/Double-precision_floating-point_format[double precision]), indicated by opcode `0x5D`
+
+Note that in the Ion data model, float values are always 64 bits. However, if a value can be losslessly serialized
+in fewer than 64 bits, applications may choose to do so.
+
+==== Example encoding of `0e0`
+[source]
+----
+┌──── Opcode in range 5A-5D indicates a float
+│┌─── Low nibble A indicates
+││    a 0-length float; 0e0
+5A
+----
+
+==== Example encoding of `3.14`
+[source]
+----
+┌──── Opcode in range 5A-5D indicates a float
+│┌─── Low nibble B indicates a 2-byte float
+││
+5B 42 47
+   └─┬─┘
+half-precision 3.14
+----
+
+==== Example encoding of `3.1415927`
+[source]
+----
+┌──── Opcode in range 5A-5D indicates a float
+│┌─── Low nibble C indicates a 4-byte,
+││    single-precision value.
+5C 40 49 0F DB
+   └────┬────┘
+single-precision 3.1415927
+----
+
+==== Example encoding of `3.141592653589793`
+[source]
+----
+┌──── Opcode in range 5A-5D indicates a float
+│┌─── Low nibble C indicates a 4-byte,
+││    single-precision value.
+5D 40 09 21 FB 54 44 2D 18
+   └──────────┬──────────┘
+double-precision 3.141592653589793
+----
+
+[[decimals]]
+=== Decimals
+
+If an opcode has a high nibble of `0x6_`, it represents a decimal. Low nibble values `0x_E` and below indicate
+the number of trailing bytes used to encode the decimal.
+
+The body of the decimal is encoded as a <<varint, `VarInt`>> representing its exponent, followed by a `FixedInt`
+representing its coefficient. The width of the coefficient is the total length of the decimal encoding minus the length
+of the exponent. It is possible for the coefficient to have a width of zero, indicating a coefficient of `0`.
+
+Decimal values that require more than 14 bytes can be encoded using the variable-length decimal opcode: `0xF6`.
+
+A decimal with a coefficient of `-0` (which cannot be encoded in a `VarInt`) is encoded using opcode `6F`.
+
+==== Example encoding of `0d0`
+[source]
+----
+┌──── Opcode in range 60-6F indicates a decimal
+│┌─── Low nibble 0 indicates a zero-byte
+││    decimal; 0d0
+60
+----
+
+==== Example encoding of `1.27`
+[source]
+----
+┌──── Opcode in range 60-6F indicates a decimal
+│┌─── Low nibble 2 indicates a 2-byte decimal
+││
+62 fd 7f
+   │  └─── Coefficient: 1-byte FixedInt 127
+   └────── Exponent: VarInt -2
+----
+
+==== Example variable-length encoding of `1.27`
+[source]
+----
+┌──── Opcode F6 indicates a variable-length decimal
+│
+F6 05 fd 7f
+   │  │  └─── Coefficient: 1-byte FixedInt 127
+   │  └────── Exponent: VarInt -2
+   └───────── Decimal length: VarUInt 2
+----
+
+==== Example variable-length encoding of `-0d3`
+[source]
+----
+┌──── Opcode 6F indicates a variable-length decimal with a coefficient of -0
+│
+6F 03 03
+   │  └────── Exponent: FixedInt 3
+   └───────── Decimal length: VarUInt 1
+----
+
+[[timestamps]]
+== Timestamps
+
+NOTE: In Ion 1.0, text timestamp fields were encoded using the local time while binary timestamp fields were encoded
+using UTC time. This required applications to perform conversion logic when transcribing from one format to the other.
+*In Ion 1.1, all binary timestamp fields are encoded in local time.*
+
+[[short_form_timestamp]]
+=== Short-form timestamp
+
+If an opcode has a high nibble of `0x7_`, it represents a short-form timestamp. This encoding focuses on making the
+most common timestamp precisions and ranges the most compact; less common precisions can still be expressed via
+the variable-length <<long_form_timestamp, long form timestamp>> encoding.
+
+Timestamps may be encoded using the short form if they meet all of the following conditions:
+
+* *The year is between 1970 and 2097*. The year subfield is encoded as the number of years since 1970. 7 bits are
+dedicated to representing the biased year, allowing timestamps through the year 2097 to be encoded in this form.
+* *The local offset is either UTC, unknown, or falls between `-14:00` to `+14:00` and is divisible by 15 minutes.* 7
+bits are dedicated to representing the local offset as the number of quarter hours from -56 (that is: offset `-14:00`).
+The value `0b1111111` indicates an unknown offset. At the time of this writing (2023-05T),
+link:https://en.wikipedia.org/wiki/List_of_UTC_offsets[all real-world offsets fall between `-12:00` and `+14:00`].
+* *The timestamp's fractional second precision (if present) is either 3 digits (milliseconds), 6 digits (microseconds),
+or 9 digits (nanoseconds).*
+
+The following letters to are used to denote bits in each subfield in diagrams that follow. Subfields occur in the same
+order in all encoding variants, and consume the same number of bits, with the exception of the fractional bits, which
+consume only enough bits to represent the fractional precision supported by the opcode being used.
+
+[cols="^1, ^1, 4"]
+|===
+|Letter code | Number of bits | Subfield
+
+| *Y*
+| 7
+| Year
+
+| *M*
+| 4
+| Month
+
+| *D*
+| 5
+| Day
+
+| *H*
+| 5
+| Hour
+
+| *m*
+| 6
+| Minute
+
+| *o*
+| 7
+| Offset
+
+| *U*
+| 1
+| Unknown or UTC offset
+
+| *s*
+|6
+| Second
+
+| *f*
+| 10 (ms) +
+20(μs) +
+30(ns) +
+| Fractional second
+
+| *-*
+| n/a
+| Unused
+|===
+
+==== Opcode `0x70`: Year (1 byte)
+[source]
+----
++=========+
+|YYYY:YYY-|
++=========+
+----
+
+==== Opcode `0x71`: Month (2 bytes)
+[source]
+----
++=========+=========+
+|YYYY:YYYM|MMM-:----|
++=========+=========+
+----
+
+==== Opcode `0x72`: Day (2 bytes)
+[source]
+----
++=========+=========+
+|YYYY:YYYM|MMMD:DDDD|
++=========+=========+
+----
+
+==== Opcode `0x73`: Hour+Minutes @ UTC or Unknown (4 bytes)
+
+NOTE: Each encoding for a precision greater than or equal to `Hour+Minutes` comes in two flavors: one that uses a single bit (`U`) to indicate UTC versus Unknown offset, and another that uses 7 bits (`o`) to encode the number of quarter-hours offset from `-14:00`.
+
+[source]
+----
++=========+=========+=========+=========+
+|YYYY:YYYM|MMMD:DDDD|HHHH:Hmmm|mmmU:----|
++=========+=========+=========+=========+
+----
+
+==== Opcode `0x74`: Hour+Minutes @ Offset (5 bytes)
+[source]
+----
++=========+=========+=========+=========+=========+
+|YYYY:YYYM|MMMD:DDDD|HHHH:Hmmm|mmmo:oooo|oo--:----|
++=========+=========+=========+=========+=========+
+----
+
+==== Opcode `0x75`: Seconds @ UTC or Unknown (5 bytes)
+[source]
+----
++=========+=========+=========+=========+=========+
+|YYYY:YYYM|MMMD:DDDD|HHHH:Hmmm|mmmU:ssss|ss--:----|
++=========+=========+=========+=========+=========+
+----
+
+==== Opcode `0x76`: Seconds @ Offset (5 bytes)
+[source]
+----
++=========+=========+=========+=========+=========+
+|YYYY:YYYM|MMMD:DDDD|HHHH:Hmmm|mmmo:oooo|oo--:----|
++=========+=========+=========+=========+=========+
+----
+
+==== Opcode `0x77`: Milliseconds @ UTC or Unknown (6 bytes)
+[source]
+----
++=========+=========+=========+=========+=========+
+|YYYY:YYYM|MMMD:DDDD|HHHH:Hmmm|mmmU:ssss|ss--:----|
++=========+=========+=========+=========+=========+
+----
+
+==== Opcode `0x78`: Milliseconds @ Offset (7 bytes)
+[source]
+----
++=========+=========+=========+=========+=========+=========+=========+
+|YYYY:YYYM|MMMD:DDDD|HHHH:Hmmm|mmmo:oooo|ooss:ssss|ffff:ffff|ff--:----|
++=========+=========+=========+=========+=========+=========+=========+
+----
+
+==== Opcode `0x79`: Microseconds @ UTC or Unknown (7 bytes)
+[source]
+----
++=========+=========+=========+=========+=========+=========+=========+
+|YYYY:YYYM|MMMD:DDDD|HHHH:Hmmm|mmmk:ssss|ssff:ffff|ffff:ffff|ffff:ff--|
++=========+=========+=========+=========+=========+=========+=========+
+----
+
+==== Opcode `0x7A`: Microseconds @ Offset (8 bytes)
+[source]
+----
++=========+=========+=========+=========+=========+=========+=========+=========+
+|YYYY:YYYM|MMMD:DDDD|HHHH:Hmmm|mmmo:oooo|ooss:ssss|ffff:ffff|ffff:ffff|ffff:----|
++=========+=========+=========+=========+=========+=========+=========+=========+
+----
+
+==== Opcode `0x7B`: Nanoseconds @ UTC or Unknown (8 bytes)
+[source]
+----
++=========+=========+=========+=========+=========+=========+=========+=========+
+|YYYY:YYYM|MMMD:DDDD|HHHH:Hmmm|mmmo:oooo|ooss:ssss|ffff:ffff|ffff:ffff|ffff:----|
++=========+=========+=========+=========+=========+=========+=========+=========+
+----
+
+==== Opcode `0x7B`: Nanoseconds @ Offset (8 bytes)
+[source]
+----
++=========+=========+=========+=========+=========+=========+=========+=========+
+|YYYY:YYYM|MMMD:DDDD|HHHH:Hmmm|mmmo:oooo|ooss:ssss|ffff:ffff|ffff:ffff|ffff:----|
++=========+=========+=========+=========+=========+=========+=========+=========+
+----
+
+WARNING: Opcodes `0x7D`, `0x7E`, and `7F` are illegal; they are reserved for future use.
+
+[[long_form_timestamp]]
+=== Long-form timestamp
+
+Unlike the <<short_form_timestamp, Short-form timestamp encoding>>, which is limited to encoding
+timestamps in the most commonly referenced timestamp ranges and precisions for which it optimizes,
+the long-form timestamp encoding is capable of representing any valid timestamp.
+
+The long form begins with opcode `0xF7`. A <<varuint, `VarUInt`>> follows indicating the number
+of bytes that were needed to represent the timestamp. The encoding consumes the minimum number
+of bytes required to represent the timestamp. The declared length can be mapped to the timestamp’s
+precision as follows:
+
+[cols="^1, 6"]
+|===
+|Length | Corresponding precision
+
+| 0
+| illegal
+
+| 1
+| illegal
+
+| 2
+| Year
+
+| 3
+| Month or Day (see below)
+
+| 4
+| Illegal. The hour cannot be specified without also specifying minutes.
+
+| 5
+| Illegal
+
+| 6
+| Minutes
+
+| 7
+| Seconds
+
+| 8 or more
+| Fractional seconds
+|===
+
+Unlike the short-form encoding, the long-form encoding reserves:
+
+* *14 bits for the year (`Y`)*, which is not biased.
+* *12 bits for the offset*, which counts the number of minutes (not quarter-hours) from -1440
+(that is: `-24:00`). An offset value of `0b111111111111` indicates an unknown offset.
+
+If the timestamp's length is greater than or equal to `8`, it has fractional seconds that are encoded as a
+`(coefficient, exponent)` pair, similar to a <<decimals, decimal>>. However, it is illegal for the fractional
+seconds value to be greater than or equal to `1.0` or less than `0.0`. For this reason, both the exponent and
+the coefficient are encoded using unsigned types. The included exponent `VarUInt` is implicitly negative, preventing
+the encoding of decimal numbers greater than `1.0`. The coefficient `FixedUInt` is unsigned to prevent the encoding of fractional seconds less than `0.0`. Note that validation is still required; namely:
+
+* An exponent value of `0` is illegal, as that would result in a fractional seconds greater than `1.0` (a whole second).
+* If `coefficient * 10^-exponent > 1.0`, that `(coefficient, exponent)` pair is illegal.
+
+If the timestamp's length is `3`, the least significant bit in the final byte (`h`) is a flag
+that indicates month (`0`) or day (`1`) precision.
+
+==== Opcode `0xF7`: Long-form timestamp
+[source]
+----
+     1         2         3         4         5         6         7       8         n
++=========+=========+=========+=========+=========+=========+=========+=======+   +=========+
+|YYYY:YYYY|YYYY:YYMM|MMDD:DDDh|HHHH:mmmm|mmoo:oooo|oooo:ooss|ssss|----|VarUInt|...|FixedUInt|...
++=========+=========+=========+=========+=========+=========+=========+=======+   +=========+
+----
+
+// TODO: The remaining sections (and others) will be added/completed in a follow-on PR
+
+[[text]]
+== Text
+
+[[strings]]
+=== Strings
+
+[[symbols_with_inline_text]]
+=== Symbols with inline text
+
+[[symbols_with_symbol_table_addresses]]
+=== Symbols with symbol table text
+
+[[binary_data]]
+== Binary data
+
+[[blobs]]
+=== Blobs
+
+[[clobs]]
+=== Clobs

--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -217,11 +217,11 @@ The meanings of each opcode are organized loosely by their high and low nibbles.
 
 |`0x0_` to `0x3_`
 |`A`-`F`
-|Single-byte macro invocations
+|E-expression with the address in the opcode
 
 |`0x4_`
 |`A`-`F`
-|Multibyte macro invocations
+|E-expression with the address as a trailing `FlexUInt`
 
 .4+|`0x5_`
 |`0`-`8`
@@ -358,13 +358,13 @@ The meanings of each opcode are organized loosely by their high and low nibbles.
 
 
 
-[[macro_invocation_with_address_in_opcode]]
-=== Macro Invocation With Address in the Opcode
+[[e_expression_with_the_address_in_the_opcode]]
+=== E-expression With the Address in the Opcode
 
 // TODO: link to macros chapter
 
-If the value of the opcode is less than `64` (`0x40`), it represents an invocation of the macro at the corresponding
-__address__—an offset within the local macro table.
+If the value of the opcode is less than `64` (`0x40`), it represents an E-expression invoking the macro at the
+corresponding __address__—an offset within the local macro table.
 
 .Figure {counter:figure}: Invocation of macro address `_7_`
 [source,%unbreakable]
@@ -382,17 +382,15 @@ __address__—an offset within the local macro table.
   FixedUInt 31
 ----
 
-// TODO: Link to macro calling conventions
-
 Note that the opcode alone tells us which macro is being invoked, but it does not supply enough information for the
 reader to parse any arguments that may follow. The parsing of arguments is described in detail in the section _Macro
 calling conventions_. (TODO: Link)
 
-[[macro_invocation_with_address_as_flexuint]]
-=== Macro Invocation With Address as `FlexUInt`
+[[e_expression_with_the_address_as_a_trailing_flexuint]]
+=== E-expression With the Address as a Trailing `FlexUInt`
 
-While invocations of macro addresses in the range `[0, 63]` can be encoded in a single byte using
-<<macro_invocation_with_address_in_opcode, invocations where the address is found in the opcode>>,
+While E-expressions invoking macro addresses in the range `[0, 63]` can be encoded in a single byte using
+<<e_expression_with_the_address_in_the_opcode, E-expressions with the address in the opcode>>,
 many applications will benefit from defining more than 64 macros.
 
 If the high nibble of the opcode is `0x4_`, then the low nibble represents the four least significant bits of the macro
@@ -1222,7 +1220,7 @@ EB 06
 ----
 
 [[symbols_with_symbol_address]]
-=== Symbols With Symbol Address
+=== Symbols With a Symbol Address
 
 Symbol values whose text can be found in the local symbol table are encoded using opcodes `0xE1` through `0xE3`:
 
@@ -1286,8 +1284,8 @@ EB 07
 [[clobs]]
 === Clobs
 
-Opcode `FF` indicates a clob--character data of an unspecified encoding. A `FlexUInt` follows that represents the clob's
-byte-length.
+Opcode `FF` indicates a clob--binary character data of an unspecified encoding. A `FlexUInt` follows that represents
+the clob's byte-length.
 
 `0xEB x08` represents `null.clob`.
 
@@ -1532,9 +1530,9 @@ EB 0B
 [[structs_with_symbol_address_field_names]]
 ==== Structs With Symbol Address Field Names
 
-An opcode with a high nibble of `0xC_` indicates a struct with symbol address field names. The lower
-nibble of the opcode indicates how many bytes were used to encode all of its nested `(field name, value)`
-pairs.
+An opcode with a high nibble of `0xC_` indicates a struct with symbol address field names (which is similar to the
+link:https://amazon-ion.github.io/ion-docs/docs/binary.html#0xd-struct[only available encoding of structs in Ion 1.0].
+The lower nibble of the opcode indicates how many bytes were used to encode all of its nested `(field name, value)` pairs.
 
 If the struct's encoded byte-length is too large to be encoded in a nibble, writers may use the `0xFC` opcode
 to write a variable-length struct with symbol address field names. The `0xFC` opcode is followed by a
@@ -1618,8 +1616,11 @@ TODO: Demonstrate splicing macro values into the struct via FlexSym escape code 
 [[delimited_structs]]
 ==== Delimited Structs
 
-Opcode `0xF3` indicates the beginning of a delimited struct with <<flexsym, `FlexSym`>> field names,
-while opcode `0xF0` closes the most recently opened delimited container that has not yet been closed.
+Opcode `0xF3` indicates the beginning of a delimited struct with <<flexsym, `FlexSym`>> field names.
+
+Unlike lists and S-expressions, structs cannot use opcode `0xF0` by itself to indicate the end of the delimited
+container. This is because `0xF0` is a valid `FlexSym` (a symbol with 16 bytes of inline text). To close the delimited
+struct, the writer emits a `0x00` byte (a `FlexSym` escape) followed by the opcode `0xF0`.
 
 NOTE: While length-prefixed structs can choose between <<structs_with_symbol_address_field_names, structs with
 symbol address field names>> and <<structs_with_flexsym_field_names, structs with `FlexSym` field names>>,
@@ -1655,8 +1656,7 @@ F3 FD 66 6F 6F 51 01 17 91 02 00 F0
 
 The opcode `0xEA` indicates an untyped null (that is: `null`, or its alias `null.null`).
 
-The opcode `0xEB` indicates a typed null; a byte follows whose value indicates the type. The byte-to-type
-mapping is as follows:
+The opcode `0xEB` indicates a typed null; a byte follows whose value represents an offset into the following table:
 
 [cols="^1a,4a"]
 |===
@@ -1699,6 +1699,10 @@ mapping is as follows:
 |`null.struct`
 |===
 
+All other byte values are reserved for future use.
+
+NOTE: Future versions of Ion may decide to generalize this into a "constants" table.
+
 .Figure {counter:figure}: Encoding of `_null_`
 [source,%unbreakable]
 ----
@@ -1717,6 +1721,9 @@ EB 05
 [[annotations]]
 == Annotations
 
+[sidebar]
+TODO: Decide whether we want an Ion 1.0-style double-length-prefixed sequence.
+
 Annotations can be encoded either <<annotations_with_symbol_addresses, as symbol addresses>>
 or <<annotations_with_flexsym_text, as ``FlexSym``s>>. In both encodings, the annotations sequence appears
 just before the value that it decorates.
@@ -1726,9 +1733,8 @@ It is illegal for an annotations sequence to appear before any of the following:
 * Another annotations sequence
 * The end of the stream
 * A <<nops, `NOP`>>
-// TODO: Links
-* An E-expression (that is: a macro invocation). To add annotations to the expansion of a macro invocation, see the
-`annotate` macro.
+* An <<e_expression_with_the_address_in_the_opcode, E-expression>> (that is: a macro invocation). To add annotations
+to the expansion of an E-expression, see the `annotate` macro. (TODO: Link)
 
 [[annotations_with_symbol_addresses]]
 === Annotations With Symbol Addresses
@@ -1849,6 +1855,10 @@ but can be used as padding to achieve a desired alignment.
 
 An opcode of `0xEC` indicates a single-byte `NOP` pad. An opcode of `0xED` indicates that a
 <<flexuint, `FlexUInt`>> follows that represents the number of additional bytes to skip.
+
+It is legal for a `NOP` to appear anywhere that a value can be encoded. It is not legal for a `NOP` to appear in
+annotation sequences or struct field names. If a `NOP` appears in place of a struct field _value_, then the associated
+field name is ignored; the `NOP` is immediately followed by the next field name, if any.
 
 .Figure {counter:figure}: Encoding of a 1-byte `_NOP_`
 [source,%unbreakable]

--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -1,21 +1,21 @@
 [[encoding_primitives]]
 == Encoding Primitives
 
-[[varuint]]
-=== `VarUInt`
+[[flexuint]]
+=== `FlexUInt`
 
 A variable-length unsigned integer.
 
-The bytes of a ``VarUInt``s are written in
+The bytes of a ``FlexUInt``s are written in
 link:https://en.wikipedia.org/wiki/Endianness:[little-endian byte order]. This means that the first bytes will contain
-the ``VarUInt``'s least significant bits.
+the ``FlexUInt``'s least significant bits.
 
-The least significant bits in the `VarUInt` indicate the number of bytes that were used to encode the integer.
-If a `VarUInt` is `_N_` bytes long, its `_N-1_` least significant bits will be `0`; a terminal `1` bit will be
+The least significant bits in the `FlexUInt` indicate the number of bytes that were used to encode the integer.
+If a `FlexUInt` is `_N_` bytes long, its `_N-1_` least significant bits will be `0`; a terminal `1` bit will be
 in the next most significant position.
-All bits that are more significant than the terminal `1` represent the magnitude of the `VarUInt`.
+All bits that are more significant than the terminal `1` represent the magnitude of the `FlexUInt`.
 
-.Figure {counter:figure}: `_VarUInt_` encoding of `_14_`
+.Figure {counter:figure}: `_FlexUInt_` encoding of `_14_`
 [source,%unbreakable]
 ----
               ┌──── Lowest bit is 1 (end), indicating
@@ -25,7 +25,7 @@ All bits that are more significant than the terminal `1` represent the magnitude
 unsigned int 14
 ----
 
-.Figure {counter:figure}: `_VarUInt_` encoding of `_729_`
+.Figure {counter:figure}: `_FlexUInt_` encoding of `_729_`
 [source,%unbreakable]
 ----
              ┌──── There's 1 zero in the least significant bits, so this
@@ -38,7 +38,7 @@ of the unsigned  of the unsigned
 integer          integer
 ----
 
-.Figure {counter:figure}: `_VarUInt_` encoding of `_21,043_`
+.Figure {counter:figure}: `_FlexUInt_` encoding of `_21,043_`
 [source,%unbreakable]
 ----
             ┌───── There are 2 zeros in the least significant bits, so this
@@ -51,26 +51,21 @@ of the unsigned  the unsigned     of the unsigned
 integer          integer          integer
 ----
 
-NOTE: Ion 1.0 uses link:https://en.wikipedia.org/wiki/Endianness[Big Endian byte order] and indicates the width of the
-integer by having
-link:https://amazon-ion.github.io/ion-docs/docs/binary.html#varuint-and-varint-fields[an `end` flag bit in the highest
- bit of each byte].
-
-[[varint]]
-=== `VarInt`
+[[flexint]]
+=== `FlexInt`
 
 A variable-length signed integer.
 
-From an encoding perspective, ``VarInt``s are structurally similar to a `VarUInt` (<<varuint, described above>>). Both
+From an encoding perspective, ``FlexInt``s are structurally similar to a `FlexUInt` (<<flexuint, described above>>). Both
 encode their bytes using little-endian byte order, and both use the count of least-significant zero bits to indicate
 how many bytes were used to encode the integer. They differ in the _interpretation_ of their bits; while a
-``VarUInt``'s bits are unsigned, a ``VarInt``'s bits are encoded using
+``FlexUInt``'s bits are unsigned, a ``FlexInt``'s bits are encoded using
 link:https://en.wikipedia.org/wiki/Two%27s_complement[two's complement notation].
 
-TIP: An implementation could choose to read a `VarInt` by instead reading a `VarUInt` and then reinterpreting its bits
+TIP: An implementation could choose to read a `FlexInt` by instead reading a `FlexUInt` and then reinterpreting its bits
 as two's complement.
 
-.Figure {counter:figure}: `_VarInt_` encoding of `_14_`
+.Figure {counter:figure}: `_FlexInt_` encoding of `_14_`
 [source,%unbreakable]
 ----
               ┌──── Lowest bit is 1 (end), indicating
@@ -80,7 +75,7 @@ as two's complement.
  2's comp. 14
 ----
 
-.Figure {counter:figure}: `_VarInt_` encoding of `_-14_`
+.Figure {counter:figure}: `_FlexInt_` encoding of `_-14_`
 [source,%unbreakable]
 ----
               ┌──── Lowest bit is 1 (end), indicating
@@ -90,7 +85,7 @@ as two's complement.
  2's comp. -14
 ----
 
-.Figure {counter:figure}: `_VarInt_` encoding of `_729_`
+.Figure {counter:figure}: `_FlexInt_` encoding of `_729_`
 [source,%unbreakable]
 ----
              ┌──── There's 1 zero in the least significant bits, so this
@@ -103,7 +98,7 @@ of the 2's       of the 2's
 comp. integer    comp. integer
 ----
 
-.Figure {counter:figure}: `_VarInt_` encoding of `_-729_`
+.Figure {counter:figure}: `_FlexInt_` encoding of `_-729_`
 [source,%unbreakable]
 ----
              ┌──── There's 1 zero in the least significant bits, so this
@@ -149,19 +144,19 @@ of the 2's       the 2's comp.    of the 2's comp.
 comp. integer    integer          integer
 ----
 
-[[varsym]]
-=== `VarSym`
+[[flexsym]]
+=== `FlexSym`
 
 A variable-length symbol token whose UTF-8 bytes can be inline, found in the symbol table, or derived from a macro
 expansion.
 
-A `VarSym` begins with a <<varint,`VarInt`>>; once this integer has been read, we can evaluate it to determine how to proceed. If the VarInt is:
+A `FlexSym` begins with a <<flexint,`FlexInt`>>; once this integer has been read, we can evaluate it to determine how to proceed. If the FlexInt is:
 
 * *greater than zero*, it represents a symbol ID. The symbol’s associated text can be found in the local symbol table.
 No more bytes follow.
-* *less than zero*, its absolute value represents a number of UTF-8 bytes that follow the `VarInt`. These bytes
+* *less than zero*, its absolute value represents a number of UTF-8 bytes that follow the `FlexInt`. These bytes
 represent the symbol’s text.
-* *exactly zero*, another byte follows that is an <<opcodes, opcode>>. The `VarSym` parser is not responsible for
+* *exactly zero*, another byte follows that is an <<opcodes, opcode>>. The `FlexSym` parser is not responsible for
 evaluating this opcode, only returning it—the caller will decide whether the opcode is legal in the current context.
 Example usages of the opcode include:
 ** Representing SID `$0` as `0x70`. (See: <<strings, Strings>>)
@@ -170,11 +165,11 @@ Example usages of the opcode include:
 pairs are spliced into the parent struct (TODO: Link)
 ** In a <<delimited_structs, delimited struct>>, terminating the sequence of `(field name, value)` pairs with `0xF0`.
 
-.Figure {counter:figure}: `_VarSym_` encoding of symbol ID `_$10_`
+.Figure {counter:figure}: `_FlexSym_` encoding of symbol ID `_$10_`
 [source,%unbreakable]
 ----
-              ┌─── The leading VarInt ends in a `1`,
-              │    no more VarInt bytes follow.
+              ┌─── The leading FlexInt ends in a `1`,
+              │    no more FlexInt bytes follow.
               │
 0 0 0 1 0 1 0 1
 └─────┬─────┘
@@ -182,11 +177,11 @@ pairs are spliced into the parent struct (TODO: Link)
   positive 10
 ----
 
-.Figure {counter:figure}: `_VarSym_` encoding of symbol text `_'hello'_`
+.Figure {counter:figure}: `_FlexSym_` encoding of symbol text `_'hello'_`
 [source,%unbreakable]
 ----
-              ┌─── The leading VarInt ends in a `1`,
-              │    no more VarInt bytes follow.
+              ┌─── The leading FlexInt ends in a `1`,
+              │    no more FlexInt bytes follow.
               │      h         e        l        l        o
 1 1 1 1 0 1 1 1  01101000  01100101 01101100 01101100 01101111
 └─────┬─────┘    └─────────────────────┬─────────────────────┘
@@ -194,11 +189,11 @@ pairs are spliced into the parent struct (TODO: Link)
   negative 5
 ----
 
-.Figure {counter:figure}: `_VarSym_` encoding of `''` (empty text) using an opcode
+.Figure {counter:figure}: `_FlexSym_` encoding of `''` (empty text) using an opcode
 [source,%unbreakable]
 ----
-              ┌─── The leading VarInt ends in a `1`,
-              │    no more VarInt bytes follow.
+              ┌─── The leading FlexInt ends in a `1`,
+              │    no more FlexInt bytes follow.
               │
 0 0 0 0 0 0 0 1  1110000
 └─────┬─────┘    └──┬──┘
@@ -280,7 +275,7 @@ The meanings of each opcode are organized loosely by their high and low nibbles.
 |_Reserved_
 
 |`2`-`F`
-<|Structs with `VarSym` field names
+<|Structs with `FlexSym` field names
 
 .9+|`0xE_`
 |`0`
@@ -293,7 +288,7 @@ The meanings of each opcode are organized loosely by their high and low nibbles.
 <|Annotations with symbol address
 
 |`7`-`9`
-<|Annotations with `VarSym` text
+<|Annotations with `FlexSym` text
 
 |`A`
 <|`null.null`
@@ -321,7 +316,7 @@ The meanings of each opcode are organized loosely by their high and low nibbles.
 <|Delimited S-expression start
 
 |`3`
-<|Delimited struct with `VarSym` field names start
+<|Delimited struct with `FlexSym` field names start
 
 |`4`
 <|Variable length prefixed macro invocation
@@ -339,7 +334,7 @@ The meanings of each opcode are organized loosely by their high and low nibbles.
 <|Variable length string
 
 |`9`
-<|Variable length symbol encoded as `VarSym`
+<|Variable length symbol encoded as `FlexSym`
 
 |`A`
 <|Variable length list
@@ -351,7 +346,7 @@ The meanings of each opcode are organized loosely by their high and low nibbles.
 <|Variable length struct with symbol address field names
 
 |`D`
-<|Variable length struct with `VarSym` field names
+<|Variable length struct with `FlexSym` field names
 
 |`E`
 <|Variable length blob
@@ -393,21 +388,21 @@ Note that the opcode alone tells us which macro is being invoked, but it does no
 reader to parse any arguments that may follow. The parsing of arguments is described in detail in the section _Macro
 calling conventions_. (TODO: Link)
 
-[[macro_invocation_with_address_as_varuint]]
-=== Macro Invocation With Address as `VarUInt`
+[[macro_invocation_with_address_as_flexuint]]
+=== Macro Invocation With Address as `FlexUInt`
 
 While invocations of macro addresses in the range `[0, 63]` can be encoded in a single byte using
 <<macro_invocation_with_address_in_opcode, invocations where the address is found in the opcode>>,
 many applications will benefit from defining more than 64 macros.
 
 If the high nibble of the opcode is `0x4_`, then the low nibble represents the four least significant bits of the macro
-address. A <<varuint, `VarUInt`>> follows that contains the remaining, more significant bits.
+address. A <<flexuint, `FlexUInt`>> follows that contains the remaining, more significant bits.
 
 Because the first 64 macro addresses can already be encoded using high nibbles `0` to `3`, the decoded value is biased
 by 64. (That is: the reader must add 64 to the decoded value. If the decoded value is `0`, the macro address that it
 represents is `64`.)
 
-Because the address is encoded using a `VarUInt`, there is no (theoretical) limit to the number of addresses that can
+Because the address is encoded using a `FlexUInt`, there is no (theoretical) limit to the number of addresses that can
 be invoked. However, larger addresses require more bytes to encode. The following table shows the number of bytes
 needed to encode invocations of macro addresses in various ranges.
 
@@ -434,12 +429,12 @@ needed to encode invocations of macro addresses in various ranges.
 .Figure {counter:figure}: Invocation of macro address `_131_`
 [source,%unbreakable]
 ----
-                               ┌─── The address VarUInt ends in a `1`,
-                               │    no more VarUInt bytes follow.
+                               ┌─── The address FlexUInt ends in a `1`,
+                               │    no more FlexUInt bytes follow.
                                │
 0 1 0 0 0 0 1 1  0 0 0 0 1 0 0 1
 └──┬──┘ └──┬──┘  └──────┬──────┘
-   │       │            └──────────── VarUInt containing the 7 most
+   │       │            └──────────── FlexUInt containing the 7 most
    │       └── 4 least significant    significant bits of the macro
 opcode high    bits of the macro      address
 nibble 4       address
@@ -453,12 +448,12 @@ Biased value  : 131
 [source,%unbreakable]
 ----
 
-                               ┌─── The address VarUInt ends in a `1`,
-                               │    no more VarUInt bytes follow.
+                               ┌─── The address FlexUInt ends in a `1`,
+                               │    no more FlexUInt bytes follow.
                                │
 0 1 0 0 1 0 1 1  1 0 0 0 1 1 1 1
 └──┬──┘ └──┬──┘  └──────┬──────┘
-   │       │            └──────────── VarUInt containing the 7 most
+   │       │            └──────────── FlexUInt containing the 7 most
    │       └── 4 least significant    significant bits of the macro
 opcode high    bits of the macro      address
 nibble 4       address
@@ -472,15 +467,15 @@ Biased value  : 1,211
 [source,%unbreakable]
 ----
 
-                              ┌─── The address VarUInt ends in `10`; the zero in the least significant
-                              │    bits indicates that one more VarUInt byte follows.
+                              ┌─── The address FlexUInt ends in `10`; the zero in the least significant
+                              │    bits indicates that one more FlexUInt byte follows.
                              ┌┴┐
 0 1 0 0 0 0 0 0  1 0 1 0 0 1 1 0  0 1 0 0 0 1 0 1
 └──┬──┘ └──┬──┘  └──────┬──────┘  └──────┬──────┘
    │       │            │                └──────────── the 8 most significant bits
    │       │            │                              of the macro address
    │       │            │
-   │       │            └──────────── VarUInt containing the next 7 most
+   │       │            └──────────── FlexUInt containing the next 7 most
    │       └── 4 least significant    significant bits of the macro
 opcode high    bits of the macro      address
 nibble 4       address
@@ -532,7 +527,7 @@ Opcode `0x50` represents integer `0`; no more bytes follow.
 
 Integers that require more than 8 bytes are encoded using the variable-length integer opcode `0xF5`,
 followed by a
-<<varuint, VarUInt>> indicating how many bytes of representation data follow.
+<<flexuint, FlexUInt>> indicating how many bytes of representation data follow.
 
 `0xEB 0x01` represents `null.int`.
 
@@ -569,8 +564,8 @@ FixedInt -944
 .Figure {counter:figure}: Encoding of integer `_-944_`
 [source,%unbreakable]
 ----
-┌──── Opcode F5 indicates a variable-length integer, VarUInt length follows
-│   ┌─── VarUInt 2; a 2-byte FixedInt follows
+┌──── Opcode F5 indicates a variable-length integer, FlexUInt length follows
+│   ┌─── FlexUInt 2; a 2-byte FixedInt follows
 │   │
 F5 05 50 FC
       └─┬─┘
@@ -661,14 +656,14 @@ EB 02
 If an opcode has a high nibble of `0x6_`, it represents a decimal. Low nibble values `0x_E` and below indicate
 the number of trailing bytes used to encode the decimal.
 
-The body of the decimal is encoded as a <<varint, `VarInt`>> representing its coefficient, followed by a `FixedInt`
+The body of the decimal is encoded as a <<flexint, `FlexInt`>> representing its coefficient, followed by a `FixedInt`
 representing its exponent. The width of the exponent is the total length of the decimal encoding minus the length
 of the coefficient. It is possible for the exponent to have a width of zero, indicating an exponent of `0`.
 
 Decimal values that require more than 14 bytes can be encoded using the variable-length decimal opcode: `0xF6`.
 
-A decimal with a coefficient of `-0` (which cannot be encoded as a `VarInt`) is encoded using opcode `6F`.
-The opcode is followed by a `VarInt` representing the exponent.
+A decimal with a coefficient of `-0` (which cannot be encoded as a `FlexInt`) is encoded using opcode `6F`.
+The opcode is followed by a `FlexInt` representing the exponent.
 
 `0xEB 0x03` represents `null.decimal`.
 
@@ -688,7 +683,7 @@ The opcode is followed by a `VarInt` representing the exponent.
 │┌─── Low nibble 1 indicates a 1-byte decimal
 ││
 60 0F
-   └─── Coefficient: VarInt 7; no more bytes follow, so exponent is implicitly 0
+   └─── Coefficient: FlexInt 7; no more bytes follow, so exponent is implicitly 0
 ----
 
 .Figure {counter:figure}: Encoding of decimal `1.27`
@@ -699,7 +694,7 @@ The opcode is followed by a `VarInt` representing the exponent.
 ││
 63 FD 01 FE
    └─┬─┘ └─── Exponent: 1-byte FixedInt -2
-     └────── Coefficient: VarInt 127
+     └────── Coefficient: FlexInt 127
 ----
 
 .Figure {counter:figure}: Variable-length encoding of decimal `_1.27_`
@@ -709,8 +704,8 @@ The opcode is followed by a `VarInt` representing the exponent.
 │
 F6 07 FD 01 FE
    │  └─┬─┘ └─── Exponent: 1-byte FixedInt -2
-   │    └────── Coefficient: VarInt 127
-   └───────── Decimal length: VarUInt 3
+   │    └────── Coefficient: FlexInt 127
+   └───────── Decimal length: FlexUInt 3
 ----
 
 .Figure {counter:figure}: Encoding of `_-0d3_`, which has a coefficient of negative zero
@@ -719,7 +714,7 @@ F6 07 FD 01 FE
 ┌──── Opcode 6F indicates a variable-length decimal with a coefficient of -0
 │
 6F 07
-   └────── Exponent: VarInt 3
+   └────── Exponent: FlexInt 3
 ----
 
 .Figure {counter:figure}: Encoding of `_null.decimal_`
@@ -1060,7 +1055,7 @@ Unlike the <<short_form_timestamp, Short-form timestamp encoding>>, which is lim
 timestamps in the most commonly referenced timestamp ranges and precisions for which it optimizes,
 the long-form timestamp encoding is capable of representing any valid timestamp.
 
-The long form begins with opcode `0xF7`. A <<varuint, `VarUInt`>> follows indicating the number
+The long form begins with opcode `0xF7`. A <<flexuint, `FlexUInt`>> follows indicating the number
 of bytes that were needed to represent the timestamp. The encoding consumes the minimum number
 of bytes required to represent the timestamp. The declared length can be mapped to the timestamp’s
 precision as follows:
@@ -1106,7 +1101,7 @@ Unlike the short-form encoding, the long-form encoding reserves:
 If the timestamp's length is greater than or equal to `8`, it has fractional seconds that are encoded as a
 `(coefficient, exponent)` pair, similar to a <<decimals, decimal>>. However, it is illegal for the fractional
 seconds value to be greater than or equal to `1.0` or less than `0.0`. For this reason, both the coefficient and
-the exponent are encoded using unsigned types. The included coefficient `VarUInt` is unsigned to prevent the encoding of
+the exponent are encoded using unsigned types. The included coefficient `FlexUInt` is unsigned to prevent the encoding of
 fractional seconds less than `0.0`. The exponent `FixedUInt` is implicitly negative, discouraging the encoding of
 decimal numbers greater than `1.0`. Note that validation is still required; namely:
 
@@ -1121,9 +1116,9 @@ treated as the least-significant bit of the hour (`H`) bits.
 [source,%unbreakable]
 ----
      1         2         3         4         5         6         7         8           n
-+=========+=========+=========+=========+=========+=========+=========+=======+   +=========+
-|YYYY:YYYY|MMYY:YYYY|hDDD:DDMM|mmmm:HHHH|oooo:oomm|ssoo:oooo|----|ssss|VarUInt|...|FixedUInt|...
-+=========+=========+=========+=========+=========+=========+=========+=======+   +=========+
++=========+=========+=========+=========+=========+=========+=========+========+   +=========+
+|YYYY:YYYY|MMYY:YYYY|hDDD:DDMM|mmmm:HHHH|oooo:oomm|ssoo:oooo|----|ssss|FlexUInt|...|FixedUInt|...
++=========+=========+=========+=========+=========+=========+=========+========+   +=========+
 ----
 
 [[text]]
@@ -1135,7 +1130,7 @@ treated as the least-significant bit of the hour (`H`) bits.
 If the high nibble of the opcode is `0x8_`, it represents a string. The low nibble of the opcode
 indicates how many UTF-8 bytes follow. Opcode `0x80` represents a string with empty text (`""`).
 
-Strings longer than 15 bytes can be encoded with the `F8` opcode, which takes a <<varuint, `VarUInt`>>-encoded length
+Strings longer than 15 bytes can be encoded with the `F8` opcode, which takes a <<flexuint, `FlexUInt`>>-encoded length
 after the opcode.
 
 `0xEB x05` represents `null.string`.
@@ -1163,7 +1158,7 @@ after the opcode.
 [source,%unbreakable]
 ----
 ┌──── Opcode F8 indicates a variable-length string
-│  ┌─── Length: VarUInt 24
+│  ┌─── Length: FlexUInt 24
 │  │   v  a  r  i  a  b  l  e     l  e  n  g  t  h     e  n  c  o  d  i  n  g
 F8 31 76 61 72 69 61 62 6C 65 20 6C 65 6E 67 74 68 20 65 6E 63 6f 64 69 6E 67
       └────────────────────────────────┬────────────────────────────────────┘
@@ -1210,7 +1205,7 @@ opcode indicates how many UTF-8 bytes follow. Opcode `0x90` represents a symbol 
 [source,%unbreakable]
 ----
 ┌──── Opcode F9 indicates a variable-length symbol with inline text
-│  ┌─── Length: VarUInt 24
+│  ┌─── Length: FlexUInt 24
 │  │   v  a  r  i  a  b  l  e     l  e  n  g  t  h     e  n  c  o  d  i  n  g
 F9 31 76 61 72 69 61 62 6C 65 20 6C 65 6E 67 74 68 20 65 6E 63 6f 64 69 6E 67
       └────────────────────────────────┬────────────────────────────────────┘
@@ -1235,7 +1230,7 @@ Symbol values whose text can be found in the local symbol table are encoded usin
 <<fixeduint, `FixedUInt`>> that follows the opcode.
 * `0xE2` represents a symbol whose address in the symbol table is a 2-byte <<fixeduint, `FixedUInt`>> that follows
 the opcode.
-* `0xE3` represents a symbol whose address in the symbol table is a <<varuint,`VarUInt`>> that follows the opcode.
+* `0xE3` represents a symbol whose address in the symbol table is a <<flexuint,`FlexUInt`>> that follows the opcode.
 
 Writers MUST encode a symbol address in the smallest number of bytes possible. For each opcode above, the symbol
 address that is decoded is biased by the number of addresses that can be encoded in fewer bytes.
@@ -1263,15 +1258,15 @@ address that is decoded is biased by the number of addresses that can be encoded
 [[blobs]]
 === Blobs
 
-Opcode `FE` indicates a blob of binary data. A `VarUInt` follows that represents the blob's byte-length.
+Opcode `FE` indicates a blob of binary data. A `FlexUInt` follows that represents the blob's byte-length.
 
 `0xEB x07` represents `null.blob`.
 
 .Figure {counter:figure}: Encoding of a blob with 24 bytes of data
 [source,%unbreakable]
 ----
-┌──── Opcode FE indicates a blob, VarUInt length follows
-│   ┌─── Length: VarUInt 24
+┌──── Opcode FE indicates a blob, FlexUInt length follows
+│   ┌─── Length: FlexUInt 24
 │   │
 FE 31 49 20 61 70 70 6c 61 75 64 20 79 6f 75 72 20 63 75 72 69 6f 73 69 74 79
       └────────────────────────────────┬────────────────────────────────────┘
@@ -1291,7 +1286,7 @@ EB 07
 [[clobs]]
 === Clobs
 
-Opcode `FF` indicates a clob--character data of an unspecified encoding. A `VarUInt` follows that represents the clob's
+Opcode `FF` indicates a clob--character data of an unspecified encoding. A `FlexUInt` follows that represents the clob's
 byte-length.
 
 `0xEB x08` represents `null.clob`.
@@ -1299,8 +1294,8 @@ byte-length.
 .Figure {counter:figure}: Encoding of a clob with 24 bytes of data
 [source,%unbreakable]
 ----
-┌──── Opcode FF indicates a clob, VarUInt length follows
-│   ┌─── Length: VarUInt 24
+┌──── Opcode FF indicates a clob, FlexUInt length follows
+│   ┌─── Length: FlexUInt 24
 │   │
 FF 31 49 20 61 70 70 6c 61 75 64 20 79 6f 75 72 20 63 75 72 69 6f 73 69 74 79
       └────────────────────────────────┬────────────────────────────────────┘
@@ -1336,7 +1331,7 @@ opcode indicates how many bytes were used to encode the child values that the li
 
 If the list's encoded byte-length is too large to be encoded in a nibble, writers may use the `0xFA` opcode
 to write a variable-length list. The `0xFA` opcode is followed by a
-<<varuint, `VarUInt`>> that indicates the list's byte length.
+<<flexuint, `FlexUInt`>> that indicates the list's byte length.
 
 `0xEB 0x09` represents `null.list`.
 
@@ -1361,10 +1356,10 @@ A6 51 01 51 02 51 03
 .Figure {counter:figure}: Length-prefixed encoding of `_["variable length list"]_`
 [source,%unbreakable]
 ----
-┌──── Opcode 0xFA indicates a variable-length list. A VarUInt length follows.
-│  ┌───── Length: VarUInt 22
-│  │  ┌────── Opcode 0xF8 indicates a variable-length string. A VarUInt length follows.
-│  │  │  ┌─────── Length: VarUInt 20
+┌──── Opcode 0xFA indicates a variable-length list. A FlexUInt length follows.
+│  ┌───── Length: FlexUInt 22
+│  │  ┌────── Opcode 0xF8 indicates a variable-length string. A FlexUInt length follows.
+│  │  │  ┌─────── Length: FlexUInt 20
 │  │  │  │   v  a  r  i  a  b  l  e     l  e  n  g  t  h     l  i  s  t
 FA 2d F8 29 76 61 72 69 61 62 6c 65 20 6c 65 6e 67 74 68 20 6c 69 73 74
       └─────────────────────────────┬─────────────────────────────────┘
@@ -1432,7 +1427,7 @@ S-expressions use the same encodings as <<lists, lists>>, but with different opc
 |Length-prefixed S-expression; low nibble of the opcode represents the byte-length.
 
 |`0xFB`
-|Variable-length prefixed S-expression; a `VarUInt` following the opcode represents the byte-length.
+|Variable-length prefixed S-expression; a `FlexUInt` following the opcode represents the byte-length.
 
 |`0xF2`
 |Starts a delimited S-expression; `0xF0` closes the most recently opened delimited container.
@@ -1461,10 +1456,10 @@ B6 51 01 51 02 51 03
 .Figure {counter:figure}: Length-prefixed encoding of `_("variable length sexp")_`
 [source,%unbreakable]
 ----
-┌──── Opcode 0xFB indicates a variable-length list. A VarUInt length follows.
-│  ┌───── Length: VarUInt 22
-│  │  ┌────── Opcode 0xF8 indicates a variable-length string. A VarUInt length follows.
-│  │  │  ┌─────── Length: VarUInt 20
+┌──── Opcode 0xFB indicates a variable-length list. A FlexUInt length follows.
+│  ┌───── Length: FlexUInt 22
+│  │  ┌────── Opcode 0xF8 indicates a variable-length string. A FlexUInt length follows.
+│  │  │  ┌─────── Length: FlexUInt 20
 │  │  │  │   v  a  r  i  a  b  l  e     l  e  n  g  t  h     s  e  x  p
 FB 2D F8 29 76 61 72 69 61 62 6C 65 20 6C 65 6E 67 74 68 20 73 65 78 70
       └─────────────────────────────┬─────────────────────────────────┘
@@ -1520,8 +1515,8 @@ EB 0A
 Structs have 3 available encodings:
 
 . <<structs_with_symbol_address_field_names, Structs with symbol address field names>>
-. <<structs_with_varsym_field_names, Structs with `VarSym` field names>>
-. <<delimited_structs, Delimited structs with `VarSym` field names>>
+. <<structs_with_flexsym_field_names, Structs with `FlexSym` field names>>
+. <<delimited_structs, Delimited structs with `FlexSym` field names>>
 
 `0xEB 0x0B` represents `null.struct`.
 
@@ -1543,9 +1538,9 @@ pairs.
 
 If the struct's encoded byte-length is too large to be encoded in a nibble, writers may use the `0xFC` opcode
 to write a variable-length struct with symbol address field names. The `0xFC` opcode is followed by a
-<<varuint, `VarUInt`>> that indicates the byte length.
+<<flexuint, `FlexUInt`>> that indicates the byte length.
 
-Each field in the struct is encoded as a <<varuint, `VarUInt`>> representing the address of the field name's
+Each field in the struct is encoded as a <<flexuint, `FlexUInt`>> representing the address of the field name's
 text in the symbol table, followed by an opcode-prefixed value.
 
 .Figure {counter:figure}: Length-prefixed encoding of an empty struct (`_{}_`)
@@ -1560,8 +1555,8 @@ C0
 [source,%unbreakable]
 ----
 ┌──── An opcode in the range 0xC0-0xCF indicates a struct with symbol address field names
-│  ┌─── Field name: VarUInt 10 ($10)
-│  │        ┌─── Field name: VarUInt 11 ($11)
+│  ┌─── Field name: FlexUInt 10 ($10)
+│  │        ┌─── Field name: FlexUInt 11 ($11)
 │  │        │
 C6 15 51 01 17 51 02
       └─┬─┘    └─┬─┘
@@ -1572,18 +1567,18 @@ C6 15 51 01 17 51 02
 [source,%unbreakable]
 ----
  ┌───────────── Opcode `FC` indicates a variable length struct with symbol address field names
- │  ┌────────── Length: VarUInt 25
- │  │  ┌─────── Field name: VarUInt 10 ($10)
+ │  ┌────────── Length: FlexUInt 25
+ │  │  ┌─────── Field name: FlexUInt 10 ($10)
  │  │  │  ┌──── Opcode `F8` indicates a variable length string
- │  │  │  │  ┌─ VarUInt: 22 the string is 22 bytes long
+ │  │  │  │  ┌─ FlexUInt: 22 the string is 22 bytes long
  │  │  │  │  │  v  a  r  i  a  b  l  e     l  e  n  g  t  h     s  t  r  u  c  t
 FC 33 15 F8 2D 76 61 72 69 61 62 6c 65 20 6c 65 6e 67 74 68 20 73 74 72 75 63 74
                └─────────────────────────────┬─────────────────────────────────┘
                                         UTF-8 bytes
 ----
 
-[[structs_with_varsym_field_names]]
-==== Structs With `VarSym` Field Names
+[[structs_with_flexsym_field_names]]
+==== Structs With `FlexSym` Field Names
 
 NOTE: This encoding is very similar to <<structs_with_symbol_address_field_names, structs with symbol address
 field names>>, but allows writers to choose between representing each field name as a symbol address
@@ -1591,7 +1586,7 @@ field names>>, but allows writers to choose between representing each field name
 dense, but offers writers significant flexibility over whether and when field names are added to the
 symbol table.
 
-An opcode with a high nibble of `0xD_` indicates a struct with <<varsym, `VarSym`>> field names. The lower
+An opcode with a high nibble of `0xD_` indicates a struct with <<flexsym, `FlexSym`>> field names. The lower
 nibble of the opcode indicates how many bytes were used to encode all of its nested `(field name, value)`
 pairs.
 
@@ -1599,17 +1594,17 @@ WARNING: This form cannot be used to encode an empty struct; `0xD0` is a reserve
 using either the length-prefixed form `0xC0` or the <<delimited_structs, delimited form>> `0xF3 0xF0`.
 
 If the struct's encoded byte-length is too large to be encoded in a nibble, writers may use the `0xFD` opcode
-to write a variable-length struct with <<varsym, `VarSym`>> field names. The `0xFD` opcode is followed by a
-<<varuint, `VarUInt`>> that indicates the byte length.
+to write a variable-length struct with <<flexsym, `FlexSym`>> field names. The `0xFD` opcode is followed by a
+<<flexuint, `FlexUInt`>> that indicates the byte length.
 
-Each field in the struct is encoded as a  <<varsym, `VarSym`>> field name, followed by an opcode-prefixed value.
+Each field in the struct is encoded as a  <<flexsym, `FlexSym`>> field name, followed by an opcode-prefixed value.
 
 .Figure {counter:figure}: Length-prefixed encoding of `_{"foo": 1, $11: 2}_`
 [source,%unbreakable]
 ----
-┌─── Opcode with high nibble `D` indicates a struct with VarSym field names
+┌─── Opcode with high nibble `D` indicates a struct with FlexSym field names
 │┌── Length: 9
-││ ┌─ VarSym -3      ┌─ VarSym: 11 ($11)
+││ ┌─ FlexSym -3     ┌─ FlexSym: 11 ($11)
 ││ │   f  o  o       │
 D9 FD 66 6F 6F 51 01 17 91 02
       └──┬───┘ └─┬─┘    └─┬─┘
@@ -1618,23 +1613,23 @@ D9 FD 66 6F 6F 51 01 17 91 02
 ----
 
 [sidebar]
-TODO: Demonstrate splicing macro values into the struct via VarSym escape code `0x00`.
+TODO: Demonstrate splicing macro values into the struct via FlexSym escape code `0x00`.
 
 [[delimited_structs]]
 ==== Delimited Structs
 
-Opcode `0xF3` indicates the beginning of a delimited struct with <<varsym, `VarSym`>> field names,
+Opcode `0xF3` indicates the beginning of a delimited struct with <<flexsym, `FlexSym`>> field names,
 while opcode `0xF0` closes the most recently opened delimited container that has not yet been closed.
 
 NOTE: While length-prefixed structs can choose between <<structs_with_symbol_address_field_names, structs with
-symbol address field names>> and <<structs_with_varsym_field_names, structs with `VarSym` field names>>,
-delimited structs always use `VarSym`-encoded field names.
+symbol address field names>> and <<structs_with_flexsym_field_names, structs with `FlexSym` field names>>,
+delimited structs always use `FlexSym`-encoded field names.
 
 .Figure {counter:figure}: Delimited encoding of the empty struct (`_{}_`)
 [source,%unbreakable]
 ----
-┌─── Opcode 0xF3 indicates the beginning of a delimited struct with `VarSym` field names.
-│  ┌─── VarSym escape code 0x00: an opcode follows
+┌─── Opcode 0xF3 indicates the beginning of a delimited struct with `FlexSym` field names.
+│  ┌─── FlexSym escape code 0x00: an opcode follows
 │  │  ┌─── Opcode 0xF0 indicates the end of the most
 │  │  │    recently opened delimited container
 F3 00 F0
@@ -1643,10 +1638,10 @@ F3 00 F0
 .Figure {counter:figure}: Delimited encoding of `_{"foo": 1, $11: 2}_`
 [source,%unbreakable]
 ----
-┌─── Opcode 0xF3 indicates the beginning of a delimited struct with `VarSym` field names.
+┌─── Opcode 0xF3 indicates the beginning of a delimited struct with `FlexSym` field names.
 │
-│  ┌─ VarSym -3      ┌─ VarSym: 11 ($11)
-│  │                 │        ┌─── VarSym escape code 0x00: an opcode follows
+│  ┌─ FlexSym -3     ┌─ FlexSym: 11 ($11)
+│  │                 │        ┌─── FlexSym escape code 0x00: an opcode follows
 │  │                 │        │  ┌─── Opcode 0xF0 indicates the end of the most
 │  │   f  o  o       │        │  │    recently opened delimited container
 F3 FD 66 6F 6F 51 01 17 91 02 00 F0
@@ -1723,7 +1718,7 @@ EB 05
 == Annotations
 
 Annotations can be encoded either <<annotations_with_symbol_addresses, as symbol addresses>>
-or <<annotations_with_varsym_text, as ``VarSym``s>>. In both encodings, the annotations sequence appears
+or <<annotations_with_flexsym_text, as ``FlexSym``s>>. In both encodings, the annotations sequence appears
 just before the value that it decorates.
 
 It is illegal for an annotations sequence to appear before any of the following:
@@ -1736,19 +1731,19 @@ It is illegal for an annotations sequence to appear before any of the following:
 `annotate` macro.
 
 [[annotations_with_symbol_addresses]]
-==== Annotations With Symbol Addresses
+=== Annotations With Symbol Addresses
 Opcodes `0xE4` through `0xE6` indicate one or more annotations encoded as symbol addresses. If the opcode is:
 
-* `0xE4`, a single <<varuint, `VarUInt`>>-encoded symbol address follows.
-* `0xE5`, two <<varuint, `VarUInt`>>-encoded symbol addresses follow.
-* `0xE6`, a <<varuint, `VarUInt`>> follows that represents the number of bytes needed to encode
-the annotations sequence, which can be made up of any number of `VarUInt` symbol addresses.
+* `0xE4`, a single <<flexuint, `FlexUInt`>>-encoded symbol address follows.
+* `0xE5`, two <<flexuint, `FlexUInt`>>-encoded symbol addresses follow.
+* `0xE6`, a <<flexuint, `FlexUInt`>> follows that represents the number of bytes needed to encode
+the annotations sequence, which can be made up of any number of `FlexUInt` symbol addresses.
 
 .Figure {counter:figure}: Encoding of `_$10::false_`
 [source,%unbreakable]
 ----
 ┌──── The opcode `0xE4` indicates a single annotation encoded as a symbol address follows
-│  ┌──── Annotation with symbol address: VarUInt 10
+│  ┌──── Annotation with symbol address: FlexUInt 10
 E4 15 5F
       └── The annotated value: `false`
 ----
@@ -1757,8 +1752,8 @@ E4 15 5F
 [source,%unbreakable]
 ----
 ┌──── The opcode `0xE5` indicates that two annotations encoded as symbol addresses follow
-│  ┌──── Annotation with symbol address: VarUInt 10 ($10)
-│  │  ┌──── Annotation with symbol address: VarUInt 11 ($11)
+│  ┌──── Annotation with symbol address: FlexUInt 10 ($10)
+│  │  ┌──── Annotation with symbol address: FlexUInt 11 ($11)
 E5 15 17 5F
          └── The annotated value: `false`
 ----
@@ -1767,26 +1762,26 @@ E5 15 17 5F
 [source,%unbreakable]
 ----
 ┌──── The opcode `0xE6` indicates a variable-length sequence of symbol address annotations;
-│     a VarUInt follows representing the length of the sequence.
-│   ┌──── Annotations sequence length: VarUInt 3 with symbol address: VarUInt 10 ($10)
-│   │  ┌──── Annotation with symbol address: VarUInt 10 ($10)
-│   │  │  ┌──── Annotation with symbol address: VarUInt 11 ($11)
-│   │  │  │  ┌──── Annotation with symbol address: VarUInt 12 ($12)
+│     a FlexUInt follows representing the length of the sequence.
+│   ┌──── Annotations sequence length: FlexUInt 3 with symbol address: FlexUInt 10 ($10)
+│   │  ┌──── Annotation with symbol address: FlexUInt 10 ($10)
+│   │  │  ┌──── Annotation with symbol address: FlexUInt 11 ($11)
+│   │  │  │  ┌──── Annotation with symbol address: FlexUInt 12 ($12)
 E5 07 15 17 19 5F
                └── The annotated value: `false`
 ----
 
-[[annotations_with_varsym_text]]
-==== Annotations With `VarSym` Text
+[[annotations_with_flexsym_text]]
+=== Annotations With `FlexSym` Text
 
-Opcodes `0xE7` through `0xE9` indicate one or more annotations encoded as <<varsym, `VarSym`>>s.
+Opcodes `0xE7` through `0xE9` indicate one or more annotations encoded as <<flexsym, `FlexSym`>>s.
 
 If the opcode is:
 
-* `0xE7`, a single `VarSym`-encoded symbol follows.
-* `0xE8`, two `VarSym`-encoded symbols follow.
-* `0xE9`, a `VarUInt` follows that represents the byte length of the annotations sequence, which is
-made up of any number of annotations encoded as ``VarSym``s.
+* `0xE7`, a single `FlexSym`-encoded symbol follows.
+* `0xE8`, two `FlexSym`-encoded symbols follow.
+* `0xE9`, a `FlexUInt` follows that represents the byte length of the annotations sequence, which is
+made up of any number of annotations encoded as ``FlexSym``s.
 
 While this encoding is more flexible than <<annotations_with_symbol_addresses, annotations with
 symbol addresses>>, it can be slightly less compact when all the annotations are encoded as symbol
@@ -1795,19 +1790,19 @@ addresses.
 .Figure {counter:figure}: Encoding of `_$10::false_`
 [source,%unbreakable]
 ----
-┌──── The opcode `0xE7` indicates a single annotation encoded as a VarSym follows
-│  ┌──── Annotation with symbol address: VarSym 10 ($10)
+┌──── The opcode `0xE7` indicates a single annotation encoded as a FlexSym follows
+│  ┌──── Annotation with symbol address: FlexSym 10 ($10)
 E7 15 5F
       └── The annotated value: `false`
 ----
 
-==== Example encoding of `foo::false`
+=== Example encoding of `foo::false`
 [source]
 .Figure {counter:figure}: Encoding of `_foo::false_`
 [source,%unbreakable]
 ----
-┌──── The opcode `0xE7` indicates a single annotation encoded as a VarSym follows
-│  ┌──── Annotation: VarSym -3; 3 bytes of UTF-8 text follow
+┌──── The opcode `0xE7` indicates a single annotation encoded as a FlexSym follows
+│  ┌──── Annotation: FlexSym -3; 3 bytes of UTF-8 text follow
 │  │   f  o  o
 E7 FD 66 6F 6F 5F
       └──┬───┘ └── The annotated value: `false`
@@ -1815,15 +1810,15 @@ E7 FD 66 6F 6F 5F
        bytes
 ----
 
-Note that `VarSym` annotation sequences can switch between symbol address and inline text
+Note that `FlexSym` annotation sequences can switch between symbol address and inline text
 on a per-annotation basis.
 
 .Figure {counter:figure}: Encoding of `_$10::foo::false_`
 [source,%unbreakable]
 ----
-┌──── The opcode `0xE8` indicates two annotations encoded as VarSyms follow
-│  ┌──── Annotation: VarSym 10 ($10)
-│  │  ┌──── Annotation: VarSym -3; 3 bytes of UTF-8 text follow
+┌──── The opcode `0xE8` indicates two annotations encoded as FlexSyms follow
+│  ┌──── Annotation: FlexSym 10 ($10)
+│  │  ┌──── Annotation: FlexSym -3; 3 bytes of UTF-8 text follow
 │  │  │   f  o  o
 E8 15 FD 66 6F 6F 5F
          └──┬───┘ └── The annotated value: `false`
@@ -1834,11 +1829,11 @@ E8 15 FD 66 6F 6F 5F
 .Figure {counter:figure}: Encoding of `_$10::foo::$11::false_`
 [source,%unbreakable]
 ----
-┌──── The opcode `0xE9` indicates a variable-length sequence of VarSym-encoded annotations
-│  ┌──── Length: VarUInt 6
-│  │  ┌──── Annotation: VarSym 10 ($10)
-│  │  │  ┌──── Annotation: VarSym -3; 3 bytes of UTF-8 text follow
-│  │  │  │           ┌──── Annotation: VarSym 11 ($11)
+┌──── The opcode `0xE9` indicates a variable-length sequence of FlexSym-encoded annotations
+│  ┌──── Length: FlexUInt 6
+│  │  ┌──── Annotation: FlexSym 10 ($10)
+│  │  │  ┌──── Annotation: FlexSym -3; 3 bytes of UTF-8 text follow
+│  │  │  │           ┌──── Annotation: FlexSym 11 ($11)
 │  │  │  │   f  o  o │
 E9 0D 15 FD 66 6F 6F 17 5F
             └──┬───┘    └── The annotated value: `false`
@@ -1853,7 +1848,7 @@ A `NOP` (short for "no-operation") is the binary equivalent of whitespace. `NOP`
 but can be used as padding to achieve a desired alignment.
 
 An opcode of `0xEC` indicates a single-byte `NOP` pad. An opcode of `0xED` indicates that a
-<<varuint, `VarUInt`>> follows that represents the number of additional bytes to skip.
+<<flexuint, `FlexUInt`>> follows that represents the number of additional bytes to skip.
 
 .Figure {counter:figure}: Encoding of a 1-byte `_NOP_`
 [source,%unbreakable]
@@ -1866,8 +1861,8 @@ EC
 .Figure {counter:figure}: Encoding of a 4-byte `_NOP_`
 [source,%unbreakable]
 ----
-┌──── The opcode `0xED` represents a variable-length NOP pad; a VarUInt length follows
-│  ┌──── Length: VarUInt 2; two more bytes of NOP follow
+┌──── The opcode `0xED` represents a variable-length NOP pad; a FlexUInt length follows
+│  ┌──── Length: FlexUInt 2; two more bytes of NOP follow
 │  │
 ED 05 93 C6
       └─┬─┘

--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -1,8 +1,7 @@
-= Binary Encoding
 :toc:
 
 [[encoding_primitives]]
-== Encoding primitives
+== Encoding Primitives
 
 [[varuint]]
 === `VarUInt`
@@ -18,18 +17,18 @@ If a `VarUInt` is `_N_` bytes long, its `_N-1_` least significant bits will be `
 in the next most significant position.
 All bits that are more significant than the terminal `1` represent the magnitude of the `VarUInt`.
 
-==== Example encoding of VarUInt 14 ====
-[source]
+.Figure {counter:figure}: `_VarUInt_` encoding of `_14_`
+[source,%unbreakable]
 ----
-              ┌──── Lowest bit is 1 (`end`), indicating
+              ┌──── Lowest bit is 1 (end), indicating
               │     this is the only byte.
 0 0 0 1 1 1 0 1
 └─────┬─────┘
 unsigned int 14
 ----
 
-==== Example encoding of VarUInt 729 ====
-[source]
+.Figure {counter:figure}: `_VarUInt_` encoding of `_729_`
+[source,%unbreakable]
 ----
              ┌──── There's 1 zero in the least significant bits, so this
              │     integer is two bytes wide.
@@ -41,8 +40,8 @@ of the unsigned  of the unsigned
 integer          integer
 ----
 
-==== Example encoding of VarUInt 21,043 ====
-[source]
+.Figure {counter:figure}: `_VarUInt_` encoding of `_21,043_`
+[source,%unbreakable]
 ----
             ┌───── There are 2 zeros in the least significant bits, so this
             │      integer is three bytes wide.
@@ -73,8 +72,8 @@ link:https://en.wikipedia.org/wiki/Two%27s_complement[two's complement notation]
 TIP: An implementation could choose to read a `VarInt` by instead reading a `VarUInt` and then reinterpreting its bits
 as two's complement.
 
-==== Example encoding of VarInt 14 ====
-[source]
+.Figure {counter:figure}: `_VarInt_` encoding of `_14_`
+[source,%unbreakable]
 ----
               ┌──── Lowest bit is 1 (`end`), indicating
               │     this is the only byte.
@@ -83,8 +82,8 @@ as two's complement.
  2's comp. 14
 ----
 
-==== Example encoding of VarInt -14 ====
-[source]
+.Figure {counter:figure}: `_VarInt_` encoding of `_-14_`
+[source,%unbreakable]
 ----
               ┌──── Lowest bit is 1 (`end`), indicating
               │     this is the only byte.
@@ -93,8 +92,8 @@ as two's complement.
  2's comp. -14
 ----
 
-==== Example encoding of VarInt 729 ====
-[source]
+.Figure {counter:figure}: `_VarInt_` encoding of `_729_`
+[source,%unbreakable]
 ----
              ┌──── There's 1 zero in the least significant bits, so this
              │     integer is two bytes wide.
@@ -106,8 +105,8 @@ of the 2's       of the 2's
 comp. integer    comp. integer
 ----
 
-==== Example encoding of VarInt -729 ====
-[source]
+.Figure {counter:figure}: `_VarInt_` encoding of `_-729_`
+[source,%unbreakable]
 ----
              ┌──── There's 1 zero in the least significant bits, so this
              │     integer is two bytes wide.
@@ -124,8 +123,8 @@ comp. integer    comp. integer
 
 A fixed-width, little-endian, unsigned integer whose length is inferred from the context in which it appears.
 
-==== Example encoding of FixedUInt 3,954,261 ====
-[source]
+.Figure {counter:figure}: `_FixedUInt_` encoding of `_3,954,261_`
+[source,%unbreakable]
 ----
 
 0 1 0 1 0 1 0 1  0 1 0 1 0 1 1 0  0 0 1 1 1 1 0 0
@@ -141,8 +140,8 @@ integer          integer          integer
 A fixed-width, little-endian, signed integer whose length is known from the context in which it appears. Its bytes
 are interpreted as two's complement.
 
-==== Example encoding of FixedInt -3,954,261 ====
-[source]
+.Figure {counter:figure}: `_FixedInt_` encoding of `_-3,954,261_`
+[source,%unbreakable]
 ----
 
 1 0 1 0 1 0 1 1  1 0 1 0 1 0 0 1  1 1 0 0 0 0 1 1
@@ -173,8 +172,8 @@ Example usages of the opcode include:
 pairs are spliced into the parent struct (TODO: Link)
 ** In a <<delimited_structs, delimited struct>>, terminating the sequence of `(field name, value)` pairs with `0xF0`.
 
-==== Example encoding of a `VarSym` with symbol ID `$10` ====
-[source]
+.Figure {counter:figure}: `_VarSym_` encoding of symbol ID `_$10_`
+[source,%unbreakable]
 ----
               ┌─── The leading VarInt ends in a `1`,
               │    no more VarInt bytes follow.
@@ -185,8 +184,8 @@ pairs are spliced into the parent struct (TODO: Link)
   positive 10
 ----
 
-==== Example encoding of a `VarSym` with symbol text `hello` ====
-[source]
+.Figure {counter:figure}: `_VarSym_` encoding of symbol text `_'hello'_`
+[source,%unbreakable]
 ----
               ┌─── The leading VarInt ends in a `1`,
               │    no more VarInt bytes follow.
@@ -197,8 +196,8 @@ pairs are spliced into the parent struct (TODO: Link)
   negative 5
 ----
 
-==== Example encoding of `''` (symbol with empty text) using an opcode ====
-[source]
+.Figure {counter:figure}: `_VarSym_` encoding of `''` (empty text) using an opcode
+[source,%unbreakable]
 ----
               ┌─── The leading VarInt ends in a `1`,
               │    no more VarInt bytes follow.
@@ -212,10 +211,10 @@ pairs are spliced into the parent struct (TODO: Link)
 [[opcodes]]
 == Opcodes
 
-An _opcode_ is a 1-byte <<fixeduint, `FixedUInt`>> that tells the reader what the next expression represents and how the
-bytes that follow should be interpreted.
+An _opcode_ is a 1-byte <<fixeduint, `FixedUInt`>> that tells the reader what the next expression represents
+and how the bytes that follow should be interpreted.
 
-=== Overview table
+=== Overview Table
 
 The meanings of each opcode are organized loosely by their high and low nibbles.
 
@@ -224,11 +223,11 @@ The meanings of each opcode are organized loosely by their high and low nibbles.
 |High nibble | Low nibble | Meaning
 
 |`0x0_` to `0x3_`
-|`*`
+|`A`-`F`
 |Single-byte macro invocations
 
 |`0x4_`
-|`*`
+|`A`-`F`
 |Multibyte macro invocations
 
 .4+|`0x5_`
@@ -236,7 +235,7 @@ The meanings of each opcode are organized loosely by their high and low nibbles.
 |Integers up to 8 bytes wide
 
 |`9`
-<|Reserved
+<|_Reserved_
 
 |`A`-`D`
 <|Floats
@@ -245,27 +244,27 @@ The meanings of each opcode are organized loosely by their high and low nibbles.
 <|Booleans
 
 |`0x6_`
-|`*`
+|`A`-`F`
 |Decimals
 
 |`0x7_`
-|`*`
+|`A`-`F`
 |Timestamps
 
 |`0x8_`
-|`*`
+|`A`-`F`
 |Strings
 
 |`0x9_`
-|`*`
+|`A`-`F`
 |Symbols with inline text
 
 |`0xA_`
-|`*`
+|`A`-`F`
 |Lists
 
 |`0xB_`
-|`*`
+|`A`-`F`
 |S-expressions
 
 .3+|`0xC_`
@@ -273,14 +272,14 @@ The meanings of each opcode are organized loosely by their high and low nibbles.
 |Empty struct
 
 |`1`
-<|Reserved
+<|_Reserved_
 
 |`2`-`F`
 <|Structs with symbol address field names
 
 .2+|`0xD_`
 |`0`-`1`
-|Reserved
+|_Reserved_
 
 |`2`-`F`
 <|Structs with `VarSym` field names
@@ -308,7 +307,7 @@ The meanings of each opcode are organized loosely by their high and low nibbles.
 <|NOP
 
 |`E`
-<|Reserved
+<|_Reserved_
 
 |`F`
 <|System macro invocation
@@ -366,24 +365,24 @@ The meanings of each opcode are organized loosely by their high and low nibbles.
 
 
 
-[[single_byte_macro_invocations]]
-=== Single-byte macro invocations
+[[macro_invocation_with_address_in_opcode]]
+=== Macro Invocation With Address in the Opcode
 
 // TODO: link to macros chapter
 
 If the value of the opcode is less than `64` (`0x40`), it represents an invocation of the macro at the corresponding
 __address__—an offset within the local macro table.
 
-==== Example encoding of a single-byte invocation of the macro at address `7`
-[source]
+.Figure {counter:figure}: Invocation of macro address `_7_`
+[source,%unbreakable]
 ----
 0 0 0 0 0 1 1 1
 └──────┬──────┘
   FixedUInt 7
 ----
 
-==== Example encoding of an invocation of the macro at address `31`
-[source]
+.Figure {counter:figure}: invocation of macro address `_31_`
+[source,%unbreakable]
 ----
 0 0 0 1 1 1 1 1
 └──────┬──────┘
@@ -394,14 +393,14 @@ __address__—an offset within the local macro table.
 
 Note that the opcode alone tells us which macro is being invoked, but it does not supply enough information for the
 reader to parse any arguments that may follow. The parsing of arguments is described in detail in the section _Macro
-calling conventions_.
+calling conventions_. (TODO: Link)
 
-[[multi_byte_macro_invocations]]
-=== Multibyte macro invocations
+[[macro_invocation_with_address_as_varuint]]
+=== Macro Invocation With Address as `VarUInt`
 
 While invocations of macro addresses in the range `[0, 63]` can be encoded in a single byte using
-<<single_byte_macro_invocations, single byte macro invocations>>, many applications will benefit from defining more than
-64 macros.
+<<macro_invocation_with_address_in_opcode, invocations where the address is found in the opcode>>,
+many applications will benefit from defining more than 64 macros.
 
 If the high nibble of the opcode is `0x4_`, then the low nibble represents the four least significant bits of the macro
 address. A <<varuint, `VarUInt`>> follows that contains the remaining, more significant bits.
@@ -434,8 +433,8 @@ needed to encode invocations of macro addresses in various ranges.
 |25
 |===
 
-==== Example encoding of an invocation of the macro at address `131`
-[source]
+.Figure {counter:figure}: Invocation of macro address `_131_`
+[source,%unbreakable]
 ----
                                ┌─── The address VarUInt ends in a `1`,
                                │    no more VarUInt bytes follow.
@@ -452,8 +451,8 @@ Decoded value : 67
 Biased value  : 131
 ----
 
-==== Example encoding of an invocation of the macro at address `1211`
-[source]
+.Figure {counter:figure}: Invocation of macro address `_1,211_`
+[source,%unbreakable]
 ----
 
                                ┌─── The address VarUInt ends in a `1`,
@@ -471,8 +470,8 @@ Decoded value : 1,147
 Biased value  : 1,211
 ----
 
-==== Example encoding of an invocation of the macro at address `71376`
-[source]
+.Figure {counter:figure}: Invocation of macro address `_71,376_`
+[source,%unbreakable]
 ----
 
                               ┌─── The address VarUInt ends in `10`; the zero in the least significant
@@ -500,16 +499,16 @@ NOTE: From this point on in the document, example encodings are given in hexadec
 
 `0x5E` represents boolean `true`, while `0x5F` represents boolean `false`.
 
-=== Example encoding of `true`
-[source]
+.Figure {counter:figure}: Encoding of boolean `_true_`
+[source,%unbreakable]
 ----
-5e
+5E
 ----
 
-=== Example encoding of `false`
-[source]
+.Figure {counter:figure}: Encoding of boolean `_false_`
+[source,%unbreakable]
 ----
-5f
+5F
 ----
 
 [[numbers]]
@@ -526,8 +525,8 @@ Integers that require more than 8 bytes are encoded using the variable-length in
 followed by a
 <<varuint, VarUInt>> indicating how many bytes of representation data follow.
 
-==== Example encoding of `0`
-[source]
+.Figure {counter:figure}: Encoding of integer `_0_`
+[source,%unbreakable]
 ----
 ┌──── Opcode in 50-58 range indicates integer
 │┌─── Low nibble 0 indicates
@@ -535,8 +534,8 @@ followed by a
 50
 ----
 
-==== Example encoding of `17`
-[source]
+.Figure {counter:figure}: Encoding of integer `_17_`
+[source,%unbreakable]
 ----
 ┌──── Opcode in 50-58 range indicates integer
 │┌─── Low nibble 1 indicates
@@ -545,24 +544,24 @@ followed by a
     └── FixedInt 17
 ----
 
-==== Example encoding of `-944`
-[source]
+.Figure {counter:figure}: Encoding of integer `_-944_`
+[source,%unbreakable]
 ----
 ┌──── Opcode in 50-58 range indicates integer
 │┌─── Low nibble 2 indicates
 ││    that two bytes follow.
-52 50 fc
+52 50 FC
    └─┬─┘
 FixedInt -944
 ----
 
-==== Example variable-length encoding of `-944`
-[source]
+.Figure {counter:figure}: Encoding of integer `_-944_`
+[source,%unbreakable]
 ----
 ┌──── Opcode F5 indicates a variable-length integer, VarUInt length follows
 │   ┌─── VarUInt 2; a 2-byte FixedInt follows
 │   │
-F5 05 50 fc
+F5 05 50 FC
       └─┬─┘
    FixedInt -944
 ----
@@ -583,8 +582,8 @@ indicated by opcode `0x5D`
 Note that in the Ion data model, float values are always 64 bits. However, if a value can be losslessly serialized
 in fewer than 64 bits, applications may choose to do so.
 
-==== Example encoding of `0e0`
-[source]
+.Figure {counter:figure}: Encoding of float `_0e0_`
+[source,%unbreakable]
 ----
 ┌──── Opcode in range 5A-5D indicates a float
 │┌─── Low nibble A indicates
@@ -592,8 +591,8 @@ in fewer than 64 bits, applications may choose to do so.
 5A
 ----
 
-==== Example encoding of `3.14`
-[source]
+.Figure {counter:figure}: Encoding of float `_3.14e0_`
+[source,%unbreakable]
 ----
 ┌──── Opcode in range 5A-5D indicates a float
 │┌─── Low nibble B indicates a 2-byte float
@@ -603,8 +602,8 @@ in fewer than 64 bits, applications may choose to do so.
 half-precision 3.14
 ----
 
-==== Example encoding of `3.1415927`
-[source]
+.Figure {counter:figure}: Encoding of float `_3.1415927e0_`
+[source,%unbreakable]
 ----
 ┌──── Opcode in range 5A-5D indicates a float
 │┌─── Low nibble C indicates a 4-byte,
@@ -614,12 +613,12 @@ half-precision 3.14
 single-precision 3.1415927
 ----
 
-==== Example encoding of `3.141592653589793`
-[source]
+.Figure {counter:figure}: Encoding of float `_3.141592653589793e0_`
+[source,%unbreakable]
 ----
 ┌──── Opcode in range 5A-5D indicates a float
-│┌─── Low nibble C indicates a 4-byte,
-││    single-precision value.
+│┌─── Low nibble D indicates an 8-byte,
+││    double-precision value.
 5D 40 09 21 FB 54 44 2D 18
    └──────────┬──────────┘
 double-precision 3.141592653589793
@@ -640,8 +639,8 @@ Decimal values that require more than 14 bytes can be encoded using the variable
 A decimal with a coefficient of `-0` (which cannot be encoded as a `VarInt`) is encoded using opcode `6F`.
 The opcode is followed by a `VarUInt` representing the byte length and a `FixedInt` representing the exponent.
 
-==== Example encoding of `0d0`
-[source]
+.Figure {counter:figure}: Encoding of decimal `_0d0_`
+[source,%unbreakable]
 ----
 ┌──── Opcode in range 60-6F indicates a decimal
 │┌─── Low nibble 0 indicates a zero-byte
@@ -649,8 +648,8 @@ The opcode is followed by a `VarUInt` representing the byte length and a `FixedI
 60
 ----
 
-==== Example encoding of `1.27`
-[source]
+.Figure {counter:figure}: Encoding of decimal `_1.27_`
+[source,%unbreakable]
 ----
 ┌──── Opcode in range 60-6F indicates a decimal
 │┌─── Low nibble 3 indicates a 3-byte decimal
@@ -660,8 +659,8 @@ The opcode is followed by a `VarUInt` representing the byte length and a `FixedI
      └────── Coefficient: VarInt 127
 ----
 
-==== Example variable-length encoding of `1.27`
-[source]
+.Figure {counter:figure}: Variable-length encoding of decimal `_1.27_`
+[source,%unbreakable]
 ----
 ┌──── Opcode F6 indicates a variable-length decimal
 │
@@ -760,10 +759,12 @@ consume only enough bits to represent the fractional precision supported by the 
 NOTE: Timestamps are encoded in Little Endian byte order. In the diagrams below, the bytes are read from left to right
 (least significant to most significant), while the bits within each byte should be read from right to left. (Again
 least significant to most significant.) +
-While this encoding may complicate the diagrams somewhat, it guarantees that the timestamp's subfields (`year`, `month`,
+ +
+While this encoding may complicate human reading, it guarantees that the timestamp's subfields (`year`, `month`,
 etc.) occupy the same bit indexes regardless of how many bytes there are overall. (The last subfield,
 `fractional_seconds`, always begins at the same bit index when present, but can vary in length according to the
-precision.)
+precision.) This allows processors to read the Little-Endian bytes into an integer and then mask the appropriate
+bit ranges to access the subfields.
 
 ==== Opcode `0x70`: Year (1 byte)
 [source]
@@ -894,10 +895,10 @@ precision as follows:
 |Length | Corresponding precision
 
 | 0
-| illegal
+| _Illegal_
 
 | 1
-| illegal
+| _Illegal_
 
 | 2
 | Year
@@ -906,10 +907,10 @@ precision as follows:
 | Month or Day (see below)
 
 | 4
-| Illegal. The hour cannot be specified without also specifying minutes.
+| _Illegal; the hour cannot be specified without also specifying minutes_
 
 | 5
-| Illegal
+| _Illegal_
 
 | 6
 | Minutes
@@ -956,76 +957,79 @@ that indicates month (`0`) or day (`1`) precision.
 === Strings
 
 If the high nibble of the opcode is `0x8_`, it represents a string. The low nibble of the opcode
-indicates how many UTF-8 bytes follow. Opcode 0x80 represents a string with empty text ("").
+indicates how many UTF-8 bytes follow. Opcode `0x80` represents a string with empty text (`""`).
 
 Strings longer than 15 bytes can be encoded with the `F8` opcode, which takes a <<varuint, `VarUInt`>>-encoded length
 after the opcode.
 
-==== Example encoding of the empty string (`""`)
-[source]
+.Figure {counter:figure}: Encoding of the empty string, `_""_`
+[source,%unbreakable]
 ----
 ┌──── Opcode in range 80-8F indicates a string
 │┌─── Low nibble 0 indicates that no UTF-8 bytes follow
 80
 ----
 
-==== Example encoding of a 14-byte string
-[source]
+.Figure {counter:figure}: Encoding of a 14-byte string
+[source,%unbreakable]
 ----
 ┌──── Opcode in range 80-8F indicates a string
 │┌─── Low nibble E indicates that 14 UTF-8 bytes follow
 ││  f  o  u  r  t  e  e  n     b  y  t  e  s
-8E 66 6f 75 72 74 65 65 6e 20 62 79 74 65 73
+8E 66 6F 75 72 74 65 65 6E 20 62 79 74 65 73
    └──────────────────┬────────────────────┘
                  UTF-8 bytes
 ----
 
-==== Example encoding of a 24-byte string
-[source]
+.Figure {counter:figure}: Encoding of a 24-byte string
+[source,%unbreakable]
 ----
 ┌──── Opcode F8 indicates a variable-length string
 │  ┌─── Length: VarUInt 24
 │  │   v  a  r  i  a  b  l  e     l  e  n  g  t  h     e  n  c  o  d  i  n  g
-F8 31 76 61 72 69 61 62 6c 65 20 6c 65 6e 67 74 68 20 65 6e 63 6f 64 69 6e 67
+F8 31 76 61 72 69 61 62 6C 65 20 6C 65 6E 67 74 68 20 65 6E 63 6f 64 69 6E 67
       └────────────────────────────────┬────────────────────────────────────┘
                                   UTF-8 bytes
 ----
 
 [[symbols_with_inline_text]]
-=== Symbols with inline text
+=== Symbols With Inline Text
 
-==== Example encoding of a symbol with empty text (`''`)
-[source]
+If the high nibble of the opcode is `0x9_`, it represents a symbol whose text follows the opcode. The low nibble of the
+opcode indicates how many UTF-8 bytes follow. Opcode `0x90` represents a symbol with empty text (`''`).
+
+.Figure {counter:figure}: Encoding of a symbol with empty text (`_''_`)
+[source,%unbreakable]
 ----
 ┌──── Opcode in range 90-9F indicates a symbol with inline text
 │┌─── Low nibble 0 indicates that no UTF-8 bytes follow
 90
 ----
 
-==== Example encoding of a symbol with 14 bytes of inline text
-[source]
+.Figure {counter:figure}: Encoding of a symbol with 14 bytes of inline text
+[source,%unbreakable]
 ----
 ┌──── Opcode in range 90-9F indicates a symbol with inline text
 │┌─── Low nibble E indicates that 14 UTF-8 bytes follow
 ││  f  o  u  r  t  e  e  n     b  y  t  e  s
-9E 66 6f 75 72 74 65 65 6e 20 62 79 74 65 73
+9E 66 6F 75 72 74 65 65 6E 20 62 79 74 65 73
    └──────────────────┬────────────────────┘
                  UTF-8 bytes
 ----
 
-==== Example encoding of a symbol with 24 bytes of inline text
-[source]
+.Figure {counter:figure}: Encoding of a symbol with 24 bytes of inline text
+[source,%unbreakable]
 ----
 ┌──── Opcode F9 indicates a variable-length symbol with inline text
 │  ┌─── Length: VarUInt 24
 │  │   v  a  r  i  a  b  l  e     l  e  n  g  t  h     e  n  c  o  d  i  n  g
-F9 31 76 61 72 69 61 62 6c 65 20 6c 65 6e 67 74 68 20 65 6e 63 6f 64 69 6e 67
+F9 31 76 61 72 69 61 62 6C 65 20 6C 65 6E 67 74 68 20 65 6E 63 6f 64 69 6E 67
       └────────────────────────────────┬────────────────────────────────────┘
                                   UTF-8 bytes
 ----
 
-[[symbols_with_symbol_table_addresses]]
-=== Symbols with text in the symbol table
+[[symbols_with_symbol_address_text]]
+=== Symbols With Symbol Address Text
 
 Symbol values whose text can be found in the local symbol table are encoded using opcodes `0xE1` through `0xE3`:
 
@@ -1056,15 +1060,15 @@ address that is decoded is biased by the number of addresses that can be encoded
 |===
 
 [[binary_data]]
-== Binary data
+== Binary Data
 
 [[blobs]]
 === Blobs
 
 Opcode `FE` indicates a blob of binary data.
 
-==== Example encoding of a 24-byte blob
-[source]
+.Figure {counter:figure}: Encoding of a blob with 24 bytes of data
+[source,%unbreakable]
 ----
 ┌──── Opcode FE indicates a blob, VarUInt length follows
 │   ┌─── Length: VarUInt 24
@@ -1080,8 +1084,8 @@ FE 31 49 20 61 70 70 6c 61 75 64 20 79 6f 75 72 20 63 75 72 69 6f 73 69 74 79
 
 Opcode `FF` indicates a clob--character data of an unspecified encoding.
 
-==== Example encoding of a 24-byte clob
-[source]
+.Figure {counter:figure}: Encoding of a clob with 24 bytes of data
+[source,%unbreakable]
 ----
 ┌──── Opcode FF indicates a clob, VarUInt length follows
 │   ┌─── Length: VarUInt 24
@@ -1113,16 +1117,16 @@ If the list's encoded byte-length is too large to be encoded in a nibble, writer
 to write a variable-length list. The `0xFA` opcode is followed by a
 <<varuint, `VarUInt`>> that indicates the list's byte length.
 
-===== Example length-prefixed encoding of an empty list (`[]`)
-[source]
+.Figure {counter:figure}: Length-prefixed encoding of an empty list (`_[]_`)
+[source,%unbreakable]
 ----
 ┌──── An Opcode in the range 0xA0-0xAF indicates a list.
 │┌─── A low nibble of 0 indicates that the child values of this list took zero bytes to encode.
 A0
 ----
 
-===== Example encoding of `[1, 2, 3]`
-[source]
+.Figure {counter:figure}: Length-prefixed encoding of `_[1, 2, 3]_`
+[source,%unbreakable]
 ----
 ┌──── An Opcode in the range 0xA0-0xAF indicates a list.
 │┌─── A low nibble of 0 indicates that the child values of this list took zero bytes to encode.
@@ -1131,8 +1135,8 @@ A6 51 01 51 02 51 03
      1     2     3
 ----
 
-===== Example encoding of `["variable length list"]`
-[source]
+.Figure {counter:figure}: Length-prefixed encoding of `_["variable length list"]_`
+[source,%unbreakable]
 ----
 ┌──── Opcode 0xFA indicates a variable-length list. A VarUInt length follows.
 │  ┌───── Length: VarUInt 22
@@ -1144,21 +1148,21 @@ FA 2d F8 29 76 61 72 69 61 62 6c 65 20 6c 65 6e 67 74 68 20 6c 69 73 74
                           Nested string element
 ----
 
-==== Delimited encoding
+==== Delimited Encoding
 
 Opcode `0xF1` begins a delimited list, while opcode `0xF0` closes the most recently opened delimited container
 that has not yet been closed.
 
-===== Example delimited encoding of an empty list (`[]`)
-[source]
+.Figure {counter:figure}: Delimited encoding of an empty list (`_[]_`)
+[source,%unbreakable]
 ----
 ┌──── Opcode 0xF1 indicates a delimited list
 │  ┌─── Opcode 0xF0 indicates the end of the most recently opened container
 F1 F0
 ----
 
-===== Example encoding of `[1, 2, 3]`
-[source]
+.Figure {counter:figure}: Delimited encoding of `_[1, 2, 3]_`
+[source,%unbreakable]
 ----
 ┌──── Opcode 0xF1 indicates a delimited list
 │                    ┌─── Opcode 0xF0 indicates the end of
@@ -1168,8 +1172,8 @@ F1 51 01 51 02 51 03 F0
      1     2     3
 ----
 
-===== Example encoding of `[1, [2], 3]`
-[source]
+.Figure {counter:figure}: Delimited encoding of `_[1, [2], 3]_`
+[source,%unbreakable]
 ----
 ┌──── Opcode 0xF1 indicates a delimited list
 │        ┌─── Opcode 0xF1 begins a nested delimited list
@@ -1184,9 +1188,9 @@ F1 51 01 F1 51 02 F0 51 03 F0
 ----
 
 [[s_expressions]]
-=== S-expressions
+=== S-Expressions
 
-==== Length-prefixed encoding
+==== Length-prefixed Encoding
 
 An opcode with a high nibble of `0xB_` indicates a length-prefixed S-expression. The lower nibble of the
 opcode indicates how many bytes were used to encode the child values that the S-expression contains.
@@ -1195,16 +1199,16 @@ If the S-expression's encoded byte-length is too large to be encoded in a nibble
 the `0xFB` opcode to write a variable-length S-expression. The `0xFB` opcode is followed by a
 <<varuint, `VarUInt`>> that indicates the S-expression's byte length.
 
-===== Example length-prefixed encoding of an empty S-expression (`()`)
-[source]
+.Figure {counter:figure}: Length-prefixed encoding of an empty S-expression (`_()_`)
+[source,%unbreakable]
 ----
 ┌──── An Opcode in the range 0xB0-0xBF indicates an S-expression.
 │┌─── A low nibble of 0 indicates that the child values of this S-expression took zero bytes to encode.
 B0
 ----
 
-===== Example encoding of `(1 2 3)`
-[source]
+.Figure {counter:figure}: Length-prefixed encoding of `_(1 2 3)_`
+[source,%unbreakable]
 ----
 ┌──── An Opcode in the range 0xB0-0xBF indicates an S-expression.
 │┌─── A low nibble of 6 indicates that the child values of this S-expression took six bytes to encode.
@@ -1213,34 +1217,34 @@ B6 51 01 51 02 51 03
      1     2     3
 ----
 
-===== Example encoding of `("variable length sexp")`
-[source]
+.Figure {counter:figure}: Length-prefixed encoding of `_("variable length sexp")_`
+[source,%unbreakable]
 ----
 ┌──── Opcode 0xFB indicates a variable-length list. A VarUInt length follows.
 │  ┌───── Length: VarUInt 22
 │  │  ┌────── Opcode 0xF8 indicates a variable-length string. A VarUInt length follows.
 │  │  │  ┌─────── Length: VarUInt 20
 │  │  │  │   v  a  r  i  a  b  l  e     l  e  n  g  t  h     s  e  x  p
-FB 2d F8 29 76 61 72 69 61 62 6c 65 20 6c 65 6e 67 74 68 20 73 65 78 70
+FB 2D F8 29 76 61 72 69 61 62 6C 65 20 6C 65 6E 67 74 68 20 73 65 78 70
       └─────────────────────────────┬─────────────────────────────────┘
                           Nested string element
 ----
 
-==== Delimited encoding
+==== Delimited Encoding
 
 Opcode `0xF2` begins a delimited S-expression, while opcode `0xF0` closes the most recently opened
 delimited container that has not yet been closed.
 
-===== Example delimited encoding of an empty S-expression (`()`)
-[source]
+.Figure {counter:figure}: Delimited encoding of an empty S-expression (`_()_`)
+[source,%unbreakable]
 ----
 ┌──── Opcode 0xF2 indicates a delimited S-expression
 │  ┌─── Opcode 0xF0 indicates the end of the most recently opened container
 F2 F0
 ----
 
-===== Example encoding of `(1 2 3)`
-[source]
+.Figure {counter:figure}: Delimited encoding of `_(1 2 3)_`
+[source,%unbreakable]
 ----
 ┌──── Opcode 0xF2 indicates a delimited S-expression
 │                    ┌─── Opcode 0xF0 indicates the end of
@@ -1250,8 +1254,8 @@ F2 51 01 51 02 51 03 F0
      1     2     3
 ----
 
-===== Example encoding of `(1 (2) 3)`
-[source]
+.Figure {counter:figure}: Delimited encoding of `_(1 (2) 3)_`
+[source,%unbreakable]
 ----
 ┌──── Opcode 0xF2 indicates a delimited S-expression
 │        ┌─── Opcode 0xF2 begins a nested delimited S-expression
@@ -1275,7 +1279,7 @@ Structs have 3 available encodings:
 . <<delimited_structs, Delimited structs with `VarSym` field names>>
 
 [[structs_with_symbol_address_field_names]]
-==== Structs with symbol address field names
+==== Structs With Symbol Address Field Names
 
 An opcode with a high nibble of `0xC_` indicates a struct with symbol address field names. The lower
 nibble of the opcode indicates how many bytes were used to encode all of its nested `(field name, value)`
@@ -1288,16 +1292,16 @@ to write a variable-length struct with symbol address field names. The `0xFC` op
 Each field in the struct is encoded as a <<varuint, `VarUInt`>> representing the address of the field name's
 text in the symbol table, followed by an opcode-prefixed value.
 
-===== Example encoding of an empty struct (`{}`)
-[source]
+.Figure {counter:figure}: Length-prefixed encoding of an empty struct (`_{}_`)
+[source,%unbreakable]
 ----
 ┌──── An opcode in the range 0xC0-0xCF indicates a struct with symbol address field names
 │┌─── A lower nibble of 0 indicates that the struct's fields took zero bytes to encode
 C0
 ----
 
-===== Example encoding of `{$10: 1, $11: 2}`
-[source]
+.Figure {counter:figure}: Length-prefixed encoding of `_{$10: 1, $11: 2}_`
+[source,%unbreakable]
 ----
 ┌──── An opcode in the range 0xC0-0xCF indicates a struct with symbol address field names
 │  ┌─── Field name: VarUInt 10 ($10)
@@ -1308,8 +1312,8 @@ C6 15 51 01 17 51 02
         1        2
 ----
 
-===== Example encoding of `{$10: "variable length struct"}`
-[source]
+.Figure {counter:figure}: Length-prefixed encoding of `_{$10: "variable length struct"}_`
+[source,%unbreakable]
 ----
  ┌───────────── Opcode `FC` indicates a variable length struct with symbol address field names
  │  ┌────────── Length: VarUInt 25
@@ -1323,7 +1327,7 @@ FC 33 15 F8 2D 76 61 72 69 61 62 6c 65 20 6c 65 6e 67 74 68 20 73 74 72 75 63 74
 ----
 
 [[structs_with_varsym_field_names]]
-==== Structs with `VarSym` field names
+==== Structs With `VarSym` Field Names
 
 NOTE: This encoding is very similar to <<structs_with_symbol_address_field_names, structs with symbol address
 field names>>, but allows writers to choose between representing each field name as a symbol address
@@ -1345,8 +1349,8 @@ to write a variable-length struct with <<varsym, `VarSym`>> field names. The `0x
 Each field in the struct is encoded as a  <<varsym, `VarSym`>> field name, followed by an
 opcode-prefixed value.
 
-===== Example encoding of `{"foo": 1, $11: 2}`
-[source]
+.Figure {counter:figure}: Length-prefixed encoding of `_{"foo": 1, $11: 2}_`
+[source,%unbreakable]
 ----
 ┌─── Opcode with high nibble `D` indicates a struct with VarSym field names
 │┌── Length: 7
@@ -1358,10 +1362,11 @@ D9 FD 66 6F 6F 51 01 17 91 02
        bytes
 ----
 
+[sidebar]
 TODO: Demonstrate splicing macro values into the struct via VarSym escape code `0x00`.
 
 [[delimited_structs]]
-==== Delimited structs
+==== Delimited Structs
 
 Opcode `0xF3` indicates the beginning of a delimited struct with <<varsym, `VarSym`>> field names,
 while opcode `0xF0` closes the most recently opened delimited container that has not yet been closed.
@@ -1370,8 +1375,8 @@ NOTE: While length-prefixed structs can choose between <<structs_with_symbol_add
 symbol address field names>> and <<structs_with_varsym_field_names, structs with `VarSym` field names>>,
 delimited structs always use `VarSym`-encoded field names.
 
-===== Example encoding of the empty struct (`{}`)
-[source]
+.Figure {counter:figure}: Delimited encoding of the empty struct (`_{}_`)
+[source,%unbreakable]
 ----
 ┌─── Opcode 0xF3 indicates the beginning of a delimited struct with `VarSym` field names.│
 │  ┌─── VarSym escape code 0x00: an opcode follows
@@ -1380,8 +1385,8 @@ delimited structs always use `VarSym`-encoded field names.
 F3 00 F0
 ----
 
-===== Example encoding of `{"foo": 1, $11: 2}`
-[source]
+.Figure {counter:figure}: Delimited encoding of `_{"foo": 1, $11: 2}_`
+[source,%unbreakable]
 ----
 ┌─── Opcode 0xF3 indicates the beginning of a delimited struct with `VarSym` field names.
 │
@@ -1444,15 +1449,15 @@ mapping is as follows:
 |`null.struct`
 |===
 
-==== Example encoding of `null`
-[source]
+.Figure {counter:figure}: Encoding of `_null_`
+[source,%unbreakable]
 ----
 ┌──── The opcode `0xEA` represents a null (null.null)
 EA
 ----
 
-==== Example encoding of `null.string`
-[source]
+.Figure {counter:figure}: Encoding of `_null.string_`
+[source,%unbreakable]
 ----
 ┌──── The opcode `0xEB` indicates a typed null; a byte indicating the type follows
 │  ┌──── Byte 0x05 indicates the type `string`
@@ -1478,7 +1483,7 @@ It is illegal for an annotations sequence to appear before any of the following:
 `annotate` macro.
 
 [[annotations_with_symbol_addresses]]
-==== Annotations with symbol addresses
+==== Annotations With Symbol Addresses
 Opcodes `0xE4` through `0xE6` indicate one or more annotations encoded as symbol addresses. If the opcode is:
 
 * `0xE4`, a single <<varuint, `VarUInt`>>-encoded symbol address follows.
@@ -1486,8 +1491,8 @@ Opcodes `0xE4` through `0xE6` indicate one or more annotations encoded as symbol
 * `0xE6`, a <<varuint, `VarUInt`>> follows that represents the number of bytes needed to encode
 the annotations sequence, which can be made up of any number of `VarUInt` symbol addresses.
 
-==== Example encoding of `$10::false`
-[source]
+.Figure {counter:figure}: Encoding of `_$10::false_`
+[source,%unbreakable]
 ----
 ┌──── The opcode `0xE4` indicates a single annotation encoded as a symbol address follows
 │  ┌──── Annotation with symbol address: VarUInt 10
@@ -1495,8 +1500,8 @@ E4 15 5F
       └── The annotated value: `false`
 ----
 
-==== Example encoding of `$10::$11::false`
-[source]
+.Figure {counter:figure}: Encoding of `_$10::$11::false_`
+[source,%unbreakable]
 ----
 ┌──── The opcode `0xE5` indicates that two annotations encoded as symbol addresses follow
 │  ┌──── Annotation with symbol address: VarUInt 10 ($10)
@@ -1505,8 +1510,8 @@ E5 15 17 5F
          └── The annotated value: `false`
 ----
 
-==== Example encoding of `$10::$11::$12::false`
-[source]
+.Figure {counter:figure}: Encoding of `_$10::$11::$12::false_`
+[source,%unbreakable]
 ----
 ┌──── The opcode `0xE6` indicates a variable-length sequence of symbol address annotations;
 │     a VarUInt follows representing the length of the sequence.
@@ -1519,9 +1524,9 @@ E5 07 15 17 19 5F
 ----
 
 [[annotations_with_varsym_text]]
-==== Annotations with `VarSym` text
+==== Annotations With `VarSym` Text
 
-Opcodes 0xE7 through 0xE9 indicate one or more annotations encoded as <<varsym, `VarSym`>>s.
+Opcodes `0xE7` through `0xE9` indicate one or more annotations encoded as <<varsym, `VarSym`>>s.
 
 If the opcode is:
 
@@ -1534,8 +1539,8 @@ While this encoding is more flexible than <<annotations_with_symbol_addresses, a
 symbol addresses>>, it can be slightly less compact when all the annotations are encoded as symbol
 addresses.
 
-==== Example encoding of `$10::false`
-[source]
+.Figure {counter:figure}: Encoding of `_$10::false_`
+[source,%unbreakable]
 ----
 ┌──── The opcode `0xE7` indicates a single annotation encoded as a VarSym follows
 │  ┌──── Annotation with symbol address: VarSym 10 ($10)
@@ -1545,6 +1550,8 @@ E7 15 5F
 
 ==== Example encoding of `foo::false`
 [source]
+.Figure {counter:figure}: Encoding of `_foo::false_`
+[source,%unbreakable]
 ----
 ┌──── The opcode `0xE7` indicates a single annotation encoded as a VarSym follows
 │  ┌──── Annotation: VarSym -3; 3 bytes of UTF-8 text follow
@@ -1555,12 +1562,11 @@ E7 FD 66 6F 6F 5F
        bytes
 ----
 
-==== Example encoding of `$10::foo::false`
-
 Note that `VarSym` annotation sequences can switch between symbol address and inline text
 on a per-annotation basis.
 
-[source]
+.Figure {counter:figure}: Encoding of `_$10::foo::false_`
+[source,%unbreakable]
 ----
 ┌──── The opcode `0xE8` indicates two annotations encoded as VarSyms follow
 │  ┌──── Annotation: VarSym 10 ($10)
@@ -1572,9 +1578,8 @@ E8 15 FD 66 6F 6F 5F
           bytes
 ----
 
-==== Example encoding of `$10::foo::$11::false`
-
-[source]
+.Figure {counter:figure}: Encoding of `_$10::foo::$11::false_`
+[source,%unbreakable]
 ----
 ┌──── The opcode `0xE9` indicates a variable-length sequence of VarSym-encoded annotations
 │  ┌──── Length: VarUInt 6
@@ -1597,16 +1602,16 @@ but can be used as padding to achieve a desired alignment.
 An opcode of `0xEC` indicates a single-byte `NOP` pad. An opcode of `0xED` indicates that a
 <<varuint, `VarUInt`>> follows that represents the number of additional bytes to skip.
 
-==== Example encoding of a 1-byte `NOP`
-[source]
+.Figure {counter:figure}: Encoding of a 1-byte `_NOP_`
+[source,%unbreakable]
 ----
 ┌──── The opcode `0xEC` represents a 1-byte NOP pad
 │
 EC
 ----
 
-==== Example encoding of a 4-byte `NOP`
-[source]
+.Figure {counter:figure}: Encoding of a 4-byte `_NOP_`
+[source,%unbreakable]
 ----
 ┌──── The opcode `0xED` represents a variable-length NOP pad; a VarUInt length follows
 │  ┌──── Length: VarUInt 2; two more bytes of NOP follow

--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -7,7 +7,7 @@
 A variable-length unsigned integer.
 
 The bytes of a ``VarUInt``s are written in
-link:https://en.wikipedia.org/wiki/Endianness:[Little Endian byte order]. This means that the first byte will contain
+link:https://en.wikipedia.org/wiki/Endianness:[little-endian byte order]. This means that the first byte will contain
 the ``VarUInt``'s least significant bits.
 
 The least significant bits in the `VarUInt` indicate the number of bytes that were used to encode the integer.
@@ -62,7 +62,7 @@ link:https://amazon-ion.github.io/ion-docs/docs/binary.html#varuint-and-varint-f
 A variable-length signed integer.
 
 From an encoding perspective, ``VarInt``s are structurally similar to a `VarUInt` (<<varuint, described above>>). Both
-encode their bytes using Little Endian byte order, and both use the count of least-significant zero bits to indicate
+encode their bytes using little-endian byte order, and both use the count of least-significant zero bits to indicate
 how many bytes were used to encode the integer. They differ in the _interpretation_ of their bits; while a
 ``VarUInt``'s bits are unsigned, a ``VarInt``'s bits are encoded using
 link:https://en.wikipedia.org/wiki/Two%27s_complement[two's complement notation].
@@ -408,7 +408,7 @@ by 64. (That is: the reader must add 64 to the decoded value. If the decoded val
 represents is `64`.)
 
 Because the address is encoded using a `VarUInt`, there is no (theoretical) limit to the number of addresses that can
-be invoked. However, larger addresses require more bytes to encode. This following table shows the number of bytes
+be invoked. However, larger addresses require more bytes to encode. The following table shows the number of bytes
 needed to encode invocations of macro addresses in various ranges.
 
 |===
@@ -497,6 +497,8 @@ NOTE: From this point on in the document, example encodings are given in hexadec
 
 `0x5E` represents boolean `true`, while `0x5F` represents boolean `false`.
 
+`0xEB 0x00` represents `null.bool`.
+
 .Figure {counter:figure}: Encoding of boolean `_true_`
 [source,%unbreakable]
 ----
@@ -507,6 +509,15 @@ NOTE: From this point on in the document, example encodings are given in hexadec
 [source,%unbreakable]
 ----
 5F
+----
+
+.Figure {counter:figure}: Encoding of `_null.bool_`
+[source,%unbreakable]
+----
+┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
+│  ┌─── Null type: boolean
+│  │
+EB 00
 ----
 
 [[numbers]]
@@ -522,6 +533,8 @@ Opcode `0x50` represents integer `0`; no more bytes follow.
 Integers that require more than 8 bytes are encoded using the variable-length integer opcode `0xF5`,
 followed by a
 <<varuint, VarUInt>> indicating how many bytes of representation data follow.
+
+`0xEB 0x01` represents `null.int`.
 
 .Figure {counter:figure}: Encoding of integer `_0_`
 [source,%unbreakable]
@@ -564,6 +577,15 @@ F5 05 50 FC
    FixedInt -944
 ----
 
+.Figure {counter:figure}: Encoding of `_null.int_`
+[source,%unbreakable]
+----
+┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
+│  ┌─── Null type: integer
+│  │
+EB 01
+----
+
 [[floats]]
 === Floats
 
@@ -578,7 +600,9 @@ indicated by opcode `0x5C`
 indicated by opcode `0x5D`
 
 Note that in the Ion data model, float values are always 64 bits. However, if a value can be losslessly serialized
-in fewer than 64 bits, applications may choose to do so.
+in fewer than 64 bits, Ion implementations may choose to do so.
+
+`0xEB 0x02` represents `null.float`.
 
 .Figure {counter:figure}: Encoding of float `_0e0_`
 [source,%unbreakable]
@@ -622,6 +646,15 @@ single-precision 3.1415927
 double-precision 3.141592653589793
 ----
 
+.Figure {counter:figure}: Encoding of `_null.float_`
+[source,%unbreakable]
+----
+┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
+│  ┌─── Null type: float
+│  │
+EB 02
+----
+
 [[decimals]]
 === Decimals
 
@@ -635,7 +668,9 @@ of the coefficient. It is possible for the exponent to have a width of zero, ind
 Decimal values that require more than 14 bytes can be encoded using the variable-length decimal opcode: `0xF6`.
 
 A decimal with a coefficient of `-0` (which cannot be encoded as a `VarInt`) is encoded using opcode `6F`.
-The opcode is followed by a `VarUInt` representing the byte length and a `FixedInt` representing the exponent.
+The opcode is followed by a `VarInt` representing the exponent.
+
+`0xEB 0x03` represents `null.decimal`.
 
 .Figure {counter:figure}: Encoding of decimal `_0d0_`
 [source,%unbreakable]
@@ -646,7 +681,17 @@ The opcode is followed by a `VarUInt` representing the byte length and a `FixedI
 60
 ----
 
-.Figure {counter:figure}: Encoding of decimal `_1.27_`
+.Figure {counter:figure}: Encoding of decimal `_7d0_`
+[source,%unbreakable]
+----
+┌──── Opcode in range 60-6F indicates a decimal
+│┌─── Low nibble 1 indicates a 1-byte decimal
+││
+60 0F
+   └─── Coefficient: VarInt 7; no more bytes follow, so exponent is implicitly 0
+----
+
+.Figure {counter:figure}: Encoding of decimal `1.27`
 [source,%unbreakable]
 ----
 ┌──── Opcode in range 60-6F indicates a decimal
@@ -668,14 +713,22 @@ F6 07 FD 01 FE
    └───────── Decimal length: VarUInt 3
 ----
 
-==== Example variable-length encoding of `-0d3`
-[source]
+.Figure {counter:figure}: Encoding of `_-0d3_`, which has a coefficient of negative zero
+[source,%unbreakable]
 ----
 ┌──── Opcode 6F indicates a variable-length decimal with a coefficient of -0
 │
-6F 03 03
-   │  └────── Exponent: FixedInt 3
-   └───────── Decimal length: VarUInt 1
+6F 07
+   └────── Exponent: VarInt 3
+----
+
+.Figure {counter:figure}: Encoding of `_null.decimal_`
+[source,%unbreakable]
+----
+┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
+│  ┌─── Null type: decimal
+│  │
+EB 03
 ----
 
 [[timestamps]]
@@ -684,6 +737,23 @@ F6 07 FD 01 FE
 NOTE: In Ion 1.0, text timestamp fields were encoded using the local time while binary timestamp fields were encoded
 using UTC time. This required applications to perform conversion logic when transcribing from one format to the other.
 *In Ion 1.1, all binary timestamp fields are encoded in local time.*
+
+Timestamps have two encodings:
+
+Short-form timestamps:: A compact representation optimized for the most commonly used precisions and date ranges.
+
+Long-form timestamps:: A less compact representation capable of representing any timestamp in the Ion data model.
+
+`0xEB x04` represents `null.timestamp`.
+
+.Figure {counter:figure}: Encoding of `_null.timestamp_`
+[source,%unbreakable]
+----
+┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
+│  ┌─── Null type: timestamp
+│  │
+EB 04
+----
 
 [[short_form_timestamp]]
 === Short-form Timestamp
@@ -829,7 +899,7 @@ consume only enough bits to represent the fractional precision supported by the 
 | Unused
 |===
 
-Timestamps are encoded in Little Endian byte order. In the diagrams below, the first byte shows the leading opcode
+Timestamps are encoded in little-endian byte order. In the diagrams below, the first byte shows the leading opcode
 in hexadecimal; the trailing bytes show the meaning and layout of their respective bits using the letter codes defined
 in the table above.
 
@@ -1044,7 +1114,8 @@ decimal numbers greater than `1.0`. Note that validation is still required; name
 * If `coefficient * 10^-exponent > 1.0`, that `(coefficient, exponent)` pair is illegal.
 
 If the timestamp's length is `3`, the most significant bit in the final byte (`h`) is a flag
-that indicates month (`0`) or day (`1`) precision.
+that indicates month (`0`) or day (`1`) precision. If the timestamp's length is greater than `3`, the (`h`) bit is
+treated as the least-significant bit of the hour (`H`) bits.
 
 .Figure {counter:figure}: Encoding of the body of a long-form timestamp
 [source,%unbreakable]
@@ -1066,6 +1137,8 @@ indicates how many UTF-8 bytes follow. Opcode `0x80` represents a string with em
 
 Strings longer than 15 bytes can be encoded with the `F8` opcode, which takes a <<varuint, `VarUInt`>>-encoded length
 after the opcode.
+
+`0xEB x05` represents `null.string`.
 
 .Figure {counter:figure}: Encoding of the empty string, `_""_`
 [source,%unbreakable]
@@ -1097,11 +1170,22 @@ F8 31 76 61 72 69 61 62 6C 65 20 6C 65 6E 67 74 68 20 65 6E 63 6f 64 69 6E 67
                                   UTF-8 bytes
 ----
 
+.Figure {counter:figure}: Encoding of `_null.string_`
+[source,%unbreakable]
+----
+┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
+│  ┌─── Null type: string
+│  │
+EB 05
+----
+
 [[symbols_with_inline_text]]
 === Symbols With Inline Text
 
 If the high nibble of the opcode is `0x9_`, it represents a symbol whose text follows the opcode. The low nibble of the
 opcode indicates how many UTF-8 bytes follow. Opcode `0x90` represents a symbol with empty text (`''`).
+
+`0xEB x06` represents `null.symbol`.
 
 .Figure {counter:figure}: Encoding of a symbol with empty text (`_''_`)
 [source,%unbreakable]
@@ -1131,6 +1215,15 @@ opcode indicates how many UTF-8 bytes follow. Opcode `0x90` represents a symbol 
 F9 31 76 61 72 69 61 62 6C 65 20 6C 65 6E 67 74 68 20 65 6E 63 6f 64 69 6E 67
       └────────────────────────────────┬────────────────────────────────────┘
                                   UTF-8 bytes
+----
+
+.Figure {counter:figure}: Encoding of `_null.symbol_`
+[source,%unbreakable]
+----
+┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
+│  ┌─── Null type: symbol
+│  │
+EB 06
 ----
 
 [[symbols_with_symbol_address]]
@@ -1170,7 +1263,9 @@ address that is decoded is biased by the number of addresses that can be encoded
 [[blobs]]
 === Blobs
 
-Opcode `FE` indicates a blob of binary data.
+Opcode `FE` indicates a blob of binary data. A `VarUInt` follows that represents the blob's byte-length.
+
+`0xEB x07` represents `null.blob`.
 
 .Figure {counter:figure}: Encoding of a blob with 24 bytes of data
 [source,%unbreakable]
@@ -1183,11 +1278,23 @@ FE 31 49 20 61 70 70 6c 61 75 64 20 79 6f 75 72 20 63 75 72 69 6f 73 69 74 79
                             24 bytes of binary data
 ----
 
+.Figure {counter:figure}: Encoding of `_null.blob_`
+[source,%unbreakable]
+----
+┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
+│  ┌─── Null type: blob
+│  │
+EB 07
+----
+
 
 [[clobs]]
 === Clobs
 
-Opcode `FF` indicates a clob--character data of an unspecified encoding.
+Opcode `FF` indicates a clob--character data of an unspecified encoding. A `VarUInt` follows that represents the clob's
+byte-length.
+
+`0xEB x08` represents `null.clob`.
 
 .Figure {counter:figure}: Encoding of a clob with 24 bytes of data
 [source,%unbreakable]
@@ -1198,6 +1305,15 @@ Opcode `FF` indicates a clob--character data of an unspecified encoding.
 FF 31 49 20 61 70 70 6c 61 75 64 20 79 6f 75 72 20 63 75 72 69 6f 73 69 74 79
       └────────────────────────────────┬────────────────────────────────────┘
                             24 bytes of binary data
+----
+
+.Figure {counter:figure}: Encoding of `_null.clob_`
+[source,%unbreakable]
+----
+┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
+│  ┌─── Null type: clob
+│  │
+EB 08
 ----
 
 [[containers]]
@@ -1221,6 +1337,8 @@ opcode indicates how many bytes were used to encode the child values that the li
 If the list's encoded byte-length is too large to be encoded in a nibble, writers may use the `0xFA` opcode
 to write a variable-length list. The `0xFA` opcode is followed by a
 <<varuint, `VarUInt`>> that indicates the list's byte length.
+
+`0xEB 0x09` represents `null.list`.
 
 .Figure {counter:figure}: Length-prefixed encoding of an empty list (`_[]_`)
 [source,%unbreakable]
@@ -1251,6 +1369,15 @@ A6 51 01 51 02 51 03
 FA 2d F8 29 76 61 72 69 61 62 6c 65 20 6c 65 6e 67 74 68 20 6c 69 73 74
       └─────────────────────────────┬─────────────────────────────────┘
                           Nested string element
+----
+
+.Figure {counter:figure}: Encoding of `_null.list_`
+[source,%unbreakable]
+----
+┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
+│  ┌─── Null type: list
+│  │
+EB 09
 ----
 
 ==== Delimited Encoding
@@ -1295,14 +1422,23 @@ F1 51 01 F1 51 02 F0 51 03 F0
 [[s_expressions]]
 === S-Expressions
 
-==== Length-prefixed Encoding
+S-expressions use the same encodings as <<lists, lists>>, but with different opcodes.
 
-An opcode with a high nibble of `0xB_` indicates a length-prefixed S-expression. The lower nibble of the
-opcode indicates how many bytes were used to encode the child values that the S-expression contains.
+[cols="^.^1a,4a"]
+|===
+|Opcode |Encoding
 
-If the S-expression's encoded byte-length is too large to be encoded in a nibble, writers may use
-the `0xFB` opcode to write a variable-length S-expression. The `0xFB` opcode is followed by a
-<<varuint, `VarUInt`>> that indicates the S-expression's byte length.
+|`0xB0`-`0xBF`
+|Length-prefixed S-expression; low nibble of the opcode represents the byte-length.
+
+|`0xFB`
+|Variable-length prefixed S-expression; a `VarUInt` following the opcode represents the byte-length.
+
+|`0xF2`
+|Starts a delimited S-expression; `0xF0` closes the most recently opened delimited container.
+|===
+
+`0xEB 0x0A` represents `null.sexp`.
 
 .Figure {counter:figure}: Length-prefixed encoding of an empty S-expression (`_()_`)
 [source,%unbreakable]
@@ -1334,11 +1470,6 @@ FB 2D F8 29 76 61 72 69 61 62 6C 65 20 6C 65 6E 67 74 68 20 73 65 78 70
       └─────────────────────────────┬─────────────────────────────────┘
                           Nested string element
 ----
-
-==== Delimited Encoding
-
-Opcode `0xF2` begins a delimited S-expression, while opcode `0xF0` closes the most recently opened
-delimited container that has not yet been closed.
 
 .Figure {counter:figure}: Delimited encoding of an empty S-expression (`_()_`)
 [source,%unbreakable]
@@ -1374,6 +1505,15 @@ F2 51 01 F2 51 02 F0 51 03 F0
      1        2        3
 ----
 
+.Figure {counter:figure}: Encoding of `_null.sexp_`
+[source,%unbreakable]
+----
+┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
+│  ┌─── Null type: sexp
+│  │
+EB 0A
+----
+
 [[structs]]
 === Structs
 
@@ -1382,6 +1522,17 @@ Structs have 3 available encodings:
 . <<structs_with_symbol_address_field_names, Structs with symbol address field names>>
 . <<structs_with_varsym_field_names, Structs with `VarSym` field names>>
 . <<delimited_structs, Delimited structs with `VarSym` field names>>
+
+`0xEB 0x0B` represents `null.struct`.
+
+.Figure {counter:figure}: Encoding of `_null.struct_`
+[source,%unbreakable]
+----
+┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
+│  ┌─── Null type: struct
+│  │
+EB 0B
+----
 
 [[structs_with_symbol_address_field_names]]
 ==== Structs With Symbol Address Field Names
@@ -1444,21 +1595,20 @@ An opcode with a high nibble of `0xD_` indicates a struct with <<varsym, `VarSym
 nibble of the opcode indicates how many bytes were used to encode all of its nested `(field name, value)`
 pairs.
 
-WARNING: Empty length-prefixed structs MUST be written using `0xC0`. `0xD0` is a reserved opcode. Empty
-<<delimited_structs, delimited structs>> have their own encoding.
+WARNING: This form cannot be used to encode an empty struct; `0xD0` is a reserved opcode. Empty structs can be written
+using either the length-prefixed form `0xC0` or the <<delimited_structs, delimited form>> `0xF3 0xF0`.
 
 If the struct's encoded byte-length is too large to be encoded in a nibble, writers may use the `0xFD` opcode
 to write a variable-length struct with <<varsym, `VarSym`>> field names. The `0xFD` opcode is followed by a
 <<varuint, `VarUInt`>> that indicates the byte length.
 
-Each field in the struct is encoded as a  <<varsym, `VarSym`>> field name, followed by an
-opcode-prefixed value.
+Each field in the struct is encoded as a  <<varsym, `VarSym`>> field name, followed by an opcode-prefixed value.
 
 .Figure {counter:figure}: Length-prefixed encoding of `_{"foo": 1, $11: 2}_`
 [source,%unbreakable]
 ----
 ┌─── Opcode with high nibble `D` indicates a struct with VarSym field names
-│┌── Length: 7
+│┌── Length: 9
 ││ ┌─ VarSym -3      ┌─ VarSym: 11 ($11)
 ││ │   f  o  o       │
 D9 FD 66 6F 6F 51 01 17 91 02
@@ -1483,7 +1633,7 @@ delimited structs always use `VarSym`-encoded field names.
 .Figure {counter:figure}: Delimited encoding of the empty struct (`_{}_`)
 [source,%unbreakable]
 ----
-┌─── Opcode 0xF3 indicates the beginning of a delimited struct with `VarSym` field names.│
+┌─── Opcode 0xF3 indicates the beginning of a delimited struct with `VarSym` field names.
 │  ┌─── VarSym escape code 0x00: an opcode follows
 │  │  ┌─── Opcode 0xF0 indicates the end of the most
 │  │  │    recently opened delimited container
@@ -1506,7 +1656,7 @@ F3 FD 66 6F 6F 51 01 17 91 02 00 F0
 ----
 
 [[nulls]]
-=== Nulls
+== Nulls
 
 The opcode `0xEA` indicates an untyped null (that is: `null`, or its alias `null.null`).
 
@@ -1539,10 +1689,10 @@ mapping is as follows:
 |`null.symbol`
 
 |`0x07`
-|`null.clob`
+|`null.blob`
 
 |`0x08`
-|`null.blob`
+|`null.clob`
 
 |`0x09`
 |`null.list`
@@ -1566,25 +1716,23 @@ EA
 ----
 ┌──── The opcode `0xEB` indicates a typed null; a byte indicating the type follows
 │  ┌──── Byte 0x05 indicates the type `string`
-EB 0x5
+EB 05
 ----
 
 [[annotations]]
-=== Annotations
+== Annotations
 
 Annotations can be encoded either <<annotations_with_symbol_addresses, as symbol addresses>>
 or <<annotations_with_varsym_text, as ``VarSym``s>>. In both encodings, the annotations sequence appears
 just before the value that it decorates.
 
-If an annotations sequence appears before one or more additional annotations sequences, the sequences
-are concatenated.
-
 It is illegal for an annotations sequence to appear before any of the following:
 
+* Another annotations sequence
 * The end of the stream
 * A <<nops, `NOP`>>
 // TODO: Links
-* An E-expression (that is: a macro invocation). To add annotations to a macro invocation, see the
+* An E-expression (that is: a macro invocation). To add annotations to the expansion of a macro invocation, see the
 `annotate` macro.
 
 [[annotations_with_symbol_addresses]]
@@ -1699,7 +1847,7 @@ E9 0D 15 FD 66 6F 6F 17 5F
 ----
 
 [[nops]]
-=== ``NOP``s
+== ``NOP``s
 
 A `NOP` (short for "no-operation") is the binary equivalent of whitespace. `NOP` bytes have no meaning,
 but can be used as padding to achieve a desired alignment.

--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -1030,19 +1030,19 @@ the opcode.
 Writers MUST encode a symbol address in the smallest number of bytes possible. For each opcode above, the symbol
 address that is decoded is biased by the number of addresses that can be encoded in fewer bytes.
 
-[cols="^1,1,1"]
+[cols="^1a,1a,1a"]
 |===
 |Opcode |Symbol address range |Bias
 
-|*0xE1*
+|`0xE1`
 |0 to 255
 |0
 
-|*0xE2*
+|`0xE2`
 |256 to 16,640
 |256
 
-|*0xE3*
+|`0xE3`
 |16,641 to infinity
 |16,641
 |===
@@ -1262,9 +1262,9 @@ F2 51 01 F2 51 02 F0 51 03 F0
 
 Structs have 3 available encodings:
 
-. Structs with symbol address field names
-. Structs with <<varsym, `VarSym`>> field names
-. Delimited structs with `VarSym` field names
+. <<structs_with_symbol_address_field_names, Structs with symbol address field names>>
+. <<structs_with_varsym_field_names, Structs with `VarSym` field names>>
+. <<delimited_structs, Delimited structs with `VarSym` field names>>
 
 [[structs_with_symbol_address_field_names]]
 ==== Structs with symbol address field names
@@ -1319,7 +1319,7 @@ FC 33 15 F8 2D 76 61 72 69 61 62 6c 65 20 6c 65 6e 67 74 68 20 73 74 72 75 63 74
 
 NOTE: This encoding is very similar to <<structs_with_symbol_address_field_names, structs with symbol address
 field names>>, but allows writers to choose between representing each field name as a symbol address
-(for example: `$10`) or inline UTF-8 bytes (for example: `"foo"`). This encoding is potentially less
+(for example: `$10`) or as inline UTF-8 bytes (for example: `"foo"`). This encoding is potentially less
 dense, but offers writers significant flexibility over whether and when field names are added to the
 symbol table.
 
@@ -1373,3 +1373,228 @@ F3 FD 66 6F 6F 51 01 17 91 02 F0
       3 UTF-8    1        2
        bytes
 ----
+
+[[nulls]]
+=== Nulls
+
+The opcode `0xEA` indicates an untyped null (that is: `null`, or its alias `null.null`).
+
+The opcode `0xEB` indicates a typed null; a byte follows whose value indicates the type. The byte-to-type
+mapping is as follows:
+
+[cols="^1a,4a"]
+|===
+|Byte |Type
+
+|`0x00`
+|`null.bool`
+
+|`0x01`
+|`null.int`
+
+|`0x02`
+|`null.float`
+
+|`0x03`
+|`null.decimal`
+
+|`0x04`
+|`null.timestamp`
+
+|`0x05`
+|`null.string`
+
+|`0x06`
+|`null.symbol`
+
+|`0x07`
+|`null.clob`
+
+|`0x08`
+|`null.blob`
+
+|`0x09`
+|`null.list`
+
+|`0x0A`
+|`null.sexp`
+
+|`0x0B`
+|`null.struct`
+|===
+
+==== Example encoding of `null`
+[source]
+----
+┌──── The opcode `0xEA` represents a null (null.null)
+EA
+----
+
+==== Example encoding of `null.string`
+[source]
+----
+┌──── The opcode `0xEB` indicates a typed null; a byte indicating the type follows
+│  ┌──── Byte 0x05 indicates the type `string`
+EB 0x5
+----
+
+[[annotations]]
+=== Annotations
+
+Annotations can be encoded either <<annotations_with_symbol_addresses, as symbol addresses>>
+or <<annotations_with_varsym_text, as ``VarSym``s>>. In both encodings, the annotations sequence appears
+just before the value that it decorates.
+
+If an annotations sequence appears before one or more additional annotations sequences, the sequences
+are concatenated.
+
+It is illegal for an annotations sequence to appear before any of the following:
+
+* The end of the stream
+* A <<nops, `NOP`>>
+// TODO: Links
+* An E-expression (that is: a macro invocation). To add annotations to a macro invocation, see the
+`annotate` macro.
+
+If an annotations sequence appears before one or more additional annotations sequences, the sequences
+are concatenated.
+
+[[annotations_with_symbol_addresses]]
+==== Annotations with symbol addresses
+Opcodes `0xE4` through `0xE6` indicate one or more annotations encoded as symbol addresses. If the opcode is:
+
+* `0xE4`, a single <<varuint, `VarUInt`>>-encoded symbol address follows.
+* `0xE5`, two <<varuint, `VarUInt`>>-encoded symbol addresses follow.
+* `0xE6`, a <<varuint, `VarUInt`>> follows that represents the number of bytes needed to encode
+the annotations sequence, which can be made up of any number of `VarUInt` symbol addresses.
+
+==== Example encoding of `$10::false`
+[source]
+----
+┌──── The opcode `0xE4` indicates a single annotation encoded as a symbol address follows
+│  ┌──── Annotation with symbol address: VarUInt 10
+E4 15 5F
+      └── The annotated value: `false`
+----
+
+==== Example encoding of `$10::$11::false`
+[source]
+----
+┌──── The opcode `0xE5` indicates that two annotations encoded as symbol addresses follow
+│  ┌──── Annotation with symbol address: VarUInt 10 ($10)
+│  │  ┌──── Annotation with symbol address: VarUInt 11 ($11)
+E5 15 17 5F
+         └── The annotated value: `false`
+----
+
+==== Example encoding of `$10::$11::$12::false`
+[source]
+----
+┌──── The opcode `0xE6` indicates a variable-length sequence of symbol address annotations;
+│     a VarUInt follows representing the length of the sequence.
+│   ┌──── Annotations sequence length: VarUInt 3 with symbol address: VarUInt 10 ($10)
+│   │  ┌──── Annotation with symbol address: VarUInt 10 ($10)
+│   │  │  ┌──── Annotation with symbol address: VarUInt 11 ($11)
+│   │  │  │  ┌──── Annotation with symbol address: VarUInt 12 ($12)
+E5 07 15 17 19 5F
+               └── The annotated value: `false`
+----
+
+[[annotations_with_varsym_text]]
+==== Annotations with `VarSym` text
+
+Opcodes 0xE7 through 0xE9 indicate one or more annotations encoded as <<varsym, `VarSym`>>s.
+
+If the opcode is:
+
+* `0xE7`, a single `VarSym`-encoded symbol follows.
+* `0xE8`, two `VarSym`-encoded symbols follow.
+* `0xE9`, a `VarUInt` follows that represents the byte length of the annotations sequence, which is
+made up of any number of annotations encoded as ``VarSym``s.
+
+While this encoding is more flexible than <<annotations_with_symbol_addresses, annotations with
+symbol addresses>>, it can be slightly less compact when all the annotations are encoded as symbol
+addresses.
+
+==== Example encoding of `$10::false`
+[source]
+----
+┌──── The opcode `0xE7` indicates a single annotation encoded as a VarSym follows
+│  ┌──── Annotation with symbol address: VarSym 10 ($10)
+E7 15 5F
+      └── The annotated value: `false`
+----
+
+==== Example encoding of `foo::false`
+[source]
+----
+┌──── The opcode `0xE7` indicates a single annotation encoded as a VarSym follows
+│  ┌──── Annotation: VarSym -3; 3 bytes of UTF-8 text follow
+│  │   f  o  o
+E7 FD 66 6F 6F 5F
+      └──┬───┘ └── The annotated value: `false`
+      3 UTF-8
+       bytes
+----
+
+==== Example encoding of `$10::foo::false`
+
+Note that `VarSym` annotation sequences can switch between symbol address and inline text
+on a per-annotation basis.
+
+[source]
+----
+┌──── The opcode `0xE8` indicates two annotations encoded as VarSyms follow
+│  ┌──── Annotation: VarSym 10 ($10)
+│  │  ┌──── Annotation: VarSym -3; 3 bytes of UTF-8 text follow
+│  │  │   f  o  o
+E8 15 FD 66 6F 6F 5F
+         └──┬───┘ └── The annotated value: `false`
+         3 UTF-8
+          bytes
+----
+
+==== Example encoding of `$10::foo::$11::false`
+
+[source]
+----
+┌──── The opcode `0xE9` indicates a variable-length sequence of VarSym-encoded annotations
+│  ┌──── Length: VarUInt 6
+│  │  ┌──── Annotation: VarSym 10 ($10)
+│  │  │  ┌──── Annotation: VarSym -3; 3 bytes of UTF-8 text follow
+│  │  │  │           ┌──── Annotation: VarSym 11 ($11)
+│  │  │  │   f  o  o │
+E9 0D 15 FD 66 6F 6F 17 5F
+            └──┬───┘    └── The annotated value: `false`
+            3 UTF-8
+             bytes
+----
+
+[[nops]]
+=== ``NOP``s
+
+A `NOP` (short for "no-operation") is the binary equivalent of whitespace. `NOP` bytes have no meaning,
+but can be used as padding to achieve a desired alignment.
+
+An opcode of `0xEC` indicates a single-byte `NOP` pad. An opcode of `0xED` indicates that a
+<<varuint, `VarUInt`>> follows that represents the number of additional bytes to skip.
+
+==== Example encoding of a 1-byte `NOP`
+[source]
+----
+┌──── The opcode `0xEC` represents a 1-byte NOP pad
+│
+EC
+----
+
+==== Example encoding of a 4-byte `NOP`
+[source]
+----
+┌──── The opcode `0xED` represents a variable-length NOP pad; a VarUInt length follows
+│  ┌──── Length: VarUInt 2; two more bytes of NOP follow
+│  │
+ED 05 93 C6
+      └─┬─┘
+NOP bytes, values ignored
+----
+

--- a/src/main.adoc
+++ b/src/main.adoc
@@ -35,6 +35,8 @@ include::macros-by-example.adoc[]
 
 include::modules-by-example.adoc[]
 
+include::binary-encoding.adoc[]
+
 // TODO very much a WIP
 //include::semantics-intro.adoc[]
 


### PR DESCRIPTION
This PR adds an initial version the Ion 1.1 binary encoding specification. 

It does not include the binary encoding of E-expressions, which I will publish in a follow-on PR.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
