### PR TITLE
E-expression argument encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 # Created by https://www.toptal.com/developers/gitignore/api/ruby,visualstudiocode,vim,emacs
 # Edit at https://www.toptal.com/developers/gitignore?templates=ruby,visualstudiocode,vim,emacs
 
+# JetBrains
+
+.idea/
+
 ### Emacs ###
 # -*- mode: gitignore; -*-
 *~

--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -2161,6 +2161,17 @@ arguments.
 // The macro expander confirms that `null.int` matches the expected type: `number`.
 ----
 
+.Figure {counter:figure}: Encoding of E-expression `_(:foo null)_`
+[%unbreakable,source]
+----
+┌──── The opcode is less than 0x40, so it is an E-expression invoking the macro at
+│     address 0: `foo`. `foo` takes a tagged number as a parameter (`x`), so an opcode follows.
+│  ┌──── Opcode 0xEA represents an untyped null (aka `null.null`)
+00 EA
+
+// The macro expander confirms that `null` matches the expected type: `number`
+----
+
 .Figure {counter:figure}: Encoding of E-expression `_(:foo (:bar))_`
 [%unbreakable,source]
 ----

--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -217,11 +217,11 @@ The meanings of each opcode are organized loosely by their high and low nibbles.
 |High nibble | Low nibble | Meaning
 
 |`0x0_` to `0x3_`
-|`A`-`F`
+|`0`-`F`
 |E-expression with the address in the opcode
 
 |`0x4_`
-|`A`-`F`
+|`0`-`F`
 |E-expression with the address as a trailing `FlexUInt`
 
 .4+|`0x5_`
@@ -238,27 +238,27 @@ The meanings of each opcode are organized loosely by their high and low nibbles.
 <|Booleans
 
 |`0x6_`
-|`A`-`F`
+|`0`-`F`
 |Decimals
 
 |`0x7_`
-|`A`-`F`
+|`0`-`F`
 |Timestamps
 
 |`0x8_`
-|`A`-`F`
+|`0`-`F`
 |Strings
 
 |`0x9_`
-|`A`-`F`
+|`0`-`F`
 |Symbols with inline text
 
 |`0xA_`
-|`A`-`F`
+|`0`-`F`
 |Lists
 
 |`0xB_`
-|`A`-`F`
+|`0`-`F`
 |S-expressions
 
 .3+|`0xC_`

--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -2062,7 +2062,7 @@ The _core types_ are the 13 types in the Ion data model:
 [[abstract_types]]
 ===== Abstract types
 
-The _abstract types_ are unions of one or more of the <<core_types, core types>>.
+The _abstract types_ are unions of two or more of the <<core_types, core types>>.
 
 [cols="^.^1a, 6a"]
 |===

--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -19,7 +19,7 @@ in the next most significant position.
 All bits that are more significant than the terminal `1` represent the magnitude of the `FlexUInt`.
 
 .Figure {counter:figure}: `_FlexUInt_` encoding of `_14_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
               ┌──── Lowest bit is 1 (end), indicating
               │     this is the only byte.
@@ -29,7 +29,7 @@ unsigned int 14
 ----
 
 .Figure {counter:figure}: `_FlexUInt_` encoding of `_729_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
              ┌──── There's 1 zero in the least significant bits, so this
              │     integer is two bytes wide.
@@ -42,7 +42,7 @@ integer          integer
 ----
 
 .Figure {counter:figure}: `_FlexUInt_` encoding of `_21,043_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
             ┌───── There are 2 zeros in the least significant bits, so this
             │      integer is three bytes wide.
@@ -69,7 +69,7 @@ TIP: An implementation could choose to read a `FlexInt` by instead reading a `Fl
 as two's complement.
 
 .Figure {counter:figure}: `_FlexInt_` encoding of `_14_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
               ┌──── Lowest bit is 1 (end), indicating
               │     this is the only byte.
@@ -79,7 +79,7 @@ as two's complement.
 ----
 
 .Figure {counter:figure}: `_FlexInt_` encoding of `_-14_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
               ┌──── Lowest bit is 1 (end), indicating
               │     this is the only byte.
@@ -89,7 +89,7 @@ as two's complement.
 ----
 
 .Figure {counter:figure}: `_FlexInt_` encoding of `_729_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
              ┌──── There's 1 zero in the least significant bits, so this
              │     integer is two bytes wide.
@@ -102,7 +102,7 @@ comp. integer    comp. integer
 ----
 
 .Figure {counter:figure}: `_FlexInt_` encoding of `_-729_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
              ┌──── There's 1 zero in the least significant bits, so this
              │     integer is two bytes wide.
@@ -120,7 +120,7 @@ comp. integer    comp. integer
 A fixed-width, little-endian, unsigned integer whose length is inferred from the context in which it appears.
 
 .Figure {counter:figure}: `_FixedUInt_` encoding of `_3,954,261_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 
 0 1 0 1 0 1 0 1  0 1 0 1 0 1 1 0  0 0 1 1 1 1 0 0
@@ -137,7 +137,7 @@ A fixed-width, little-endian, signed integer whose length is known from the cont
 are interpreted as two's complement.
 
 .Figure {counter:figure}: `_FixedInt_` encoding of `_-3,954,261_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 
 1 0 1 0 1 0 1 1  1 0 1 0 1 0 0 1  1 1 0 0 0 0 1 1
@@ -169,7 +169,7 @@ pairs are spliced into the parent struct (TODO: Link)
 ** In a <<delimited_structs, delimited struct>>, terminating the sequence of `(field name, value)` pairs with `0xF0`.
 
 .Figure {counter:figure}: `_FlexSym_` encoding of symbol ID `_$10_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
               ┌─── The leading FlexInt ends in a `1`,
               │    no more FlexInt bytes follow.
@@ -181,7 +181,7 @@ pairs are spliced into the parent struct (TODO: Link)
 ----
 
 .Figure {counter:figure}: `_FlexSym_` encoding of symbol text `_'hello'_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
               ┌─── The leading FlexInt ends in a `1`,
               │    no more FlexInt bytes follow.
@@ -193,7 +193,7 @@ pairs are spliced into the parent struct (TODO: Link)
 ----
 
 .Figure {counter:figure}: `_FlexSym_` encoding of `''` (empty text) using an opcode
-[source,%unbreakable]
+[%unbreakable,source]
 ----
               ┌─── The leading FlexInt ends in a `1`,
               │    no more FlexInt bytes follow.
@@ -205,7 +205,7 @@ pairs are spliced into the parent struct (TODO: Link)
 ----
 
 [[opcodes]]
-=== Opcode Overview
+=== Opcodes
 
 An _opcode_ is a 1-byte <<fixeduint, `FixedUInt`>> that tells the reader what the next expression represents
 and how the bytes that follow should be interpreted.
@@ -369,7 +369,7 @@ If the value of the opcode is less than `64` (`0x40`), it represents an E-expres
 corresponding __address__—an offset within the local macro table.
 
 .Figure {counter:figure}: Invocation of macro address `_7_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 0 0 0 0 0 1 1 1
 └──────┬──────┘
@@ -377,7 +377,7 @@ corresponding __address__—an offset within the local macro table.
 ----
 
 .Figure {counter:figure}: invocation of macro address `_31_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 0 0 0 1 1 1 1 1
 └──────┬──────┘
@@ -427,7 +427,7 @@ needed to encode invocations of macro addresses in various ranges.
 |===
 
 .Figure {counter:figure}: Invocation of macro address `_131_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
                                ┌─── The address FlexUInt ends in a `1`,
                                │    no more FlexUInt bytes follow.
@@ -445,7 +445,7 @@ Biased value  : 131
 ----
 
 .Figure {counter:figure}: Invocation of macro address `_1,211_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 
                                ┌─── The address FlexUInt ends in a `1`,
@@ -464,7 +464,7 @@ Biased value  : 1,211
 ----
 
 .Figure {counter:figure}: Invocation of macro address `_71,376_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 
                               ┌─── The address FlexUInt ends in `10`; the zero in the least significant
@@ -495,19 +495,19 @@ NOTE: From this point on in the document, example encodings are given in hexadec
 `0xEB 0x00` represents `null.bool`.
 
 .Figure {counter:figure}: Encoding of boolean `_true_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 5E
 ----
 
 .Figure {counter:figure}: Encoding of boolean `_false_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 5F
 ----
 
 .Figure {counter:figure}: Encoding of `_null.bool_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
 │  ┌─── Null type: boolean
@@ -532,7 +532,7 @@ followed by a
 `0xEB 0x01` represents `null.int`.
 
 .Figure {counter:figure}: Encoding of integer `_0_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode in 50-58 range indicates integer
 │┌─── Low nibble 0 indicates
@@ -541,7 +541,7 @@ followed by a
 ----
 
 .Figure {counter:figure}: Encoding of integer `_17_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode in 50-58 range indicates integer
 │┌─── Low nibble 1 indicates
@@ -551,7 +551,7 @@ followed by a
 ----
 
 .Figure {counter:figure}: Encoding of integer `_-944_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode in 50-58 range indicates integer
 │┌─── Low nibble 2 indicates
@@ -562,7 +562,7 @@ FixedInt -944
 ----
 
 .Figure {counter:figure}: Encoding of integer `_-944_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode F5 indicates a variable-length integer, FlexUInt length follows
 │   ┌─── FlexUInt 2; a 2-byte FixedInt follows
@@ -573,7 +573,7 @@ F5 05 50 FC
 ----
 
 .Figure {counter:figure}: Encoding of `_null.int_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
 │  ┌─── Null type: integer
@@ -600,7 +600,7 @@ in fewer than 64 bits, Ion implementations may choose to do so.
 `0xEB 0x02` represents `null.float`.
 
 .Figure {counter:figure}: Encoding of float `_0e0_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode in range 5A-5D indicates a float
 │┌─── Low nibble A indicates
@@ -609,7 +609,7 @@ in fewer than 64 bits, Ion implementations may choose to do so.
 ----
 
 .Figure {counter:figure}: Encoding of float `_3.14e0_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode in range 5A-5D indicates a float
 │┌─── Low nibble B indicates a 2-byte float
@@ -620,7 +620,7 @@ half-precision 3.14
 ----
 
 .Figure {counter:figure}: Encoding of float `_3.1415927e0_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode in range 5A-5D indicates a float
 │┌─── Low nibble C indicates a 4-byte,
@@ -631,7 +631,7 @@ single-precision 3.1415927
 ----
 
 .Figure {counter:figure}: Encoding of float `_3.141592653589793e0_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode in range 5A-5D indicates a float
 │┌─── Low nibble D indicates an 8-byte,
@@ -642,7 +642,7 @@ double-precision 3.141592653589793
 ----
 
 .Figure {counter:figure}: Encoding of `_null.float_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
 │  ┌─── Null type: float
@@ -668,7 +668,7 @@ The opcode is followed by a `FlexInt` representing the exponent.
 `0xEB 0x03` represents `null.decimal`.
 
 .Figure {counter:figure}: Encoding of decimal `_0d0_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode in range 60-6F indicates a decimal
 │┌─── Low nibble 0 indicates a zero-byte
@@ -677,7 +677,7 @@ The opcode is followed by a `FlexInt` representing the exponent.
 ----
 
 .Figure {counter:figure}: Encoding of decimal `_7d0_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode in range 60-6F indicates a decimal
 │┌─── Low nibble 1 indicates a 1-byte decimal
@@ -686,8 +686,8 @@ The opcode is followed by a `FlexInt` representing the exponent.
    └─── Coefficient: FlexInt 7; no more bytes follow, so exponent is implicitly 0
 ----
 
-.Figure {counter:figure}: Encoding of decimal `1.27`
-[source,%unbreakable]
+.Figure {counter:figure}: Encoding of decimal _`1.27`_
+[%unbreakable,source]
 ----
 ┌──── Opcode in range 60-6F indicates a decimal
 │┌─── Low nibble 3 indicates a 3-byte decimal
@@ -698,7 +698,7 @@ The opcode is followed by a `FlexInt` representing the exponent.
 ----
 
 .Figure {counter:figure}: Variable-length encoding of decimal `_1.27_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode F6 indicates a variable-length decimal
 │
@@ -709,7 +709,7 @@ F6 07 FD 01 FE
 ----
 
 .Figure {counter:figure}: Encoding of `_-0d3_`, which has a coefficient of negative zero
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode 6F indicates a variable-length decimal with a coefficient of -0
 │
@@ -718,7 +718,7 @@ F6 07 FD 01 FE
 ----
 
 .Figure {counter:figure}: Encoding of `_null.decimal_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
 │  ┌─── Null type: decimal
@@ -742,7 +742,7 @@ Long-form timestamps:: A less compact representation capable of representing any
 `0xEB x04` represents `null.timestamp`.
 
 .Figure {counter:figure}: Encoding of `_null.timestamp_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
 │  ┌─── Null type: timestamp
@@ -1279,7 +1279,7 @@ after the opcode.
 `0xEB x05` represents `null.string`.
 
 .Figure {counter:figure}: Encoding of the empty string, `_""_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode in range 80-8F indicates a string
 │┌─── Low nibble 0 indicates that no UTF-8 bytes follow
@@ -1287,7 +1287,7 @@ after the opcode.
 ----
 
 .Figure {counter:figure}: Encoding of a 14-byte string
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode in range 80-8F indicates a string
 │┌─── Low nibble E indicates that 14 UTF-8 bytes follow
@@ -1298,7 +1298,7 @@ after the opcode.
 ----
 
 .Figure {counter:figure}: Encoding of a 24-byte string
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode F8 indicates a variable-length string
 │  ┌─── Length: FlexUInt 24
@@ -1309,7 +1309,7 @@ F8 31 76 61 72 69 61 62 6C 65 20 6C 65 6E 67 74 68 20 65 6E 63 6f 64 69 6E 67
 ----
 
 .Figure {counter:figure}: Encoding of `_null.string_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
 │  ┌─── Null type: string
@@ -1326,7 +1326,7 @@ opcode indicates how many UTF-8 bytes follow. Opcode `0x90` represents a symbol 
 `0xEB x06` represents `null.symbol`.
 
 .Figure {counter:figure}: Encoding of a symbol with empty text (`_''_`)
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode in range 90-9F indicates a symbol with inline text
 │┌─── Low nibble 0 indicates that no UTF-8 bytes follow
@@ -1334,7 +1334,7 @@ opcode indicates how many UTF-8 bytes follow. Opcode `0x90` represents a symbol 
 ----
 
 .Figure {counter:figure}: Encoding of a symbol with 14 bytes of inline text
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode in range 90-9F indicates a symbol with inline text
 │┌─── Low nibble E indicates that 14 UTF-8 bytes follow
@@ -1345,7 +1345,7 @@ opcode indicates how many UTF-8 bytes follow. Opcode `0x90` represents a symbol 
 ----
 
 .Figure {counter:figure}: Encoding of a symbol with 24 bytes of inline text
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode F9 indicates a variable-length symbol with inline text
 │  ┌─── Length: FlexUInt 24
@@ -1356,7 +1356,7 @@ F9 31 76 61 72 69 61 62 6C 65 20 6C 65 6E 67 74 68 20 65 6E 63 6f 64 69 6E 67
 ----
 
 .Figure {counter:figure}: Encoding of `_null.symbol_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
 │  ┌─── Null type: symbol
@@ -1406,7 +1406,7 @@ Opcode `FE` indicates a blob of binary data. A `FlexUInt` follows that represent
 `0xEB x07` represents `null.blob`.
 
 .Figure {counter:figure}: Encoding of a blob with 24 bytes of data
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode FE indicates a blob, FlexUInt length follows
 │   ┌─── Length: FlexUInt 24
@@ -1417,7 +1417,7 @@ FE 31 49 20 61 70 70 6c 61 75 64 20 79 6f 75 72 20 63 75 72 69 6f 73 69 74 79
 ----
 
 .Figure {counter:figure}: Encoding of `_null.blob_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
 │  ┌─── Null type: blob
@@ -1435,7 +1435,7 @@ the clob's byte-length.
 `0xEB x08` represents `null.clob`.
 
 .Figure {counter:figure}: Encoding of a clob with 24 bytes of data
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode FF indicates a clob, FlexUInt length follows
 │   ┌─── Length: FlexUInt 24
@@ -1446,7 +1446,7 @@ FF 31 49 20 61 70 70 6c 61 75 64 20 79 6f 75 72 20 63 75 72 69 6f 73 69 74 79
 ----
 
 .Figure {counter:figure}: Encoding of `_null.clob_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
 │  ┌─── Null type: clob
@@ -1479,7 +1479,7 @@ to write a variable-length list. The `0xFA` opcode is followed by a
 `0xEB 0x09` represents `null.list`.
 
 .Figure {counter:figure}: Length-prefixed encoding of an empty list (`_[]_`)
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── An Opcode in the range 0xA0-0xAF indicates a list.
 │┌─── A low nibble of 0 indicates that the child values of this list took zero bytes to encode.
@@ -1487,7 +1487,7 @@ A0
 ----
 
 .Figure {counter:figure}: Length-prefixed encoding of `_[1, 2, 3]_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── An Opcode in the range 0xA0-0xAF indicates a list.
 │┌─── A low nibble of 0 indicates that the child values of this list took zero bytes to encode.
@@ -1497,7 +1497,7 @@ A6 51 01 51 02 51 03
 ----
 
 .Figure {counter:figure}: Length-prefixed encoding of `_["variable length list"]_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode 0xFA indicates a variable-length list. A FlexUInt length follows.
 │  ┌───── Length: FlexUInt 22
@@ -1510,7 +1510,7 @@ FA 2d F8 29 76 61 72 69 61 62 6c 65 20 6c 65 6e 67 74 68 20 6c 69 73 74
 ----
 
 .Figure {counter:figure}: Encoding of `_null.list_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
 │  ┌─── Null type: list
@@ -1524,7 +1524,7 @@ Opcode `0xF1` begins a delimited list, while opcode `0xF0` closes the most recen
 that has not yet been closed.
 
 .Figure {counter:figure}: Delimited encoding of an empty list (`_[]_`)
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode 0xF1 indicates a delimited list
 │  ┌─── Opcode 0xF0 indicates the end of the most recently opened container
@@ -1532,7 +1532,7 @@ F1 F0
 ----
 
 .Figure {counter:figure}: Delimited encoding of `_[1, 2, 3]_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode 0xF1 indicates a delimited list
 │                    ┌─── Opcode 0xF0 indicates the end of
@@ -1543,7 +1543,7 @@ F1 51 01 51 02 51 03 F0
 ----
 
 .Figure {counter:figure}: Delimited encoding of `_[1, [2], 3]_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode 0xF1 indicates a delimited list
 │        ┌─── Opcode 0xF1 begins a nested delimited list
@@ -1579,7 +1579,7 @@ S-expressions use the same encodings as <<lists, lists>>, but with different opc
 `0xEB 0x0A` represents `null.sexp`.
 
 .Figure {counter:figure}: Length-prefixed encoding of an empty S-expression (`_()_`)
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── An Opcode in the range 0xB0-0xBF indicates an S-expression.
 │┌─── A low nibble of 0 indicates that the child values of this S-expression took zero bytes to encode.
@@ -1587,7 +1587,7 @@ B0
 ----
 
 .Figure {counter:figure}: Length-prefixed encoding of `_(1 2 3)_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── An Opcode in the range 0xB0-0xBF indicates an S-expression.
 │┌─── A low nibble of 6 indicates that the child values of this S-expression took six bytes to encode.
@@ -1597,7 +1597,7 @@ B6 51 01 51 02 51 03
 ----
 
 .Figure {counter:figure}: Length-prefixed encoding of `_("variable length sexp")_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode 0xFB indicates a variable-length list. A FlexUInt length follows.
 │  ┌───── Length: FlexUInt 22
@@ -1610,7 +1610,7 @@ FB 2D F8 29 76 61 72 69 61 62 6C 65 20 6C 65 6E 67 74 68 20 73 65 78 70
 ----
 
 .Figure {counter:figure}: Delimited encoding of an empty S-expression (`_()_`)
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode 0xF2 indicates a delimited S-expression
 │  ┌─── Opcode 0xF0 indicates the end of the most recently opened container
@@ -1618,7 +1618,7 @@ F2 F0
 ----
 
 .Figure {counter:figure}: Delimited encoding of `_(1 2 3)_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode 0xF2 indicates a delimited S-expression
 │                    ┌─── Opcode 0xF0 indicates the end of
@@ -1629,7 +1629,7 @@ F2 51 01 51 02 51 03 F0
 ----
 
 .Figure {counter:figure}: Delimited encoding of `_(1 (2) 3)_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode 0xF2 indicates a delimited S-expression
 │        ┌─── Opcode 0xF2 begins a nested delimited S-expression
@@ -1644,7 +1644,7 @@ F2 51 01 F2 51 02 F0 51 03 F0
 ----
 
 .Figure {counter:figure}: Encoding of `_null.sexp_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
 │  ┌─── Null type: sexp
@@ -1664,7 +1664,7 @@ Structs have 3 available encodings:
 `0xEB 0x0B` represents `null.struct`.
 
 .Figure {counter:figure}: Encoding of `_null.struct_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── Opcode 0xEB indicates a typed null; a byte follows specifying the type
 │  ┌─── Null type: struct
@@ -1687,7 +1687,7 @@ Each field in the struct is encoded as a <<flexuint, `FlexUInt`>> representing t
 text in the symbol table, followed by an opcode-prefixed value.
 
 .Figure {counter:figure}: Length-prefixed encoding of an empty struct (`_{}_`)
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── An opcode in the range 0xC0-0xCF indicates a struct with symbol address field names
 │┌─── A lower nibble of 0 indicates that the struct's fields took zero bytes to encode
@@ -1695,7 +1695,7 @@ C0
 ----
 
 .Figure {counter:figure}: Length-prefixed encoding of `_{$10: 1, $11: 2}_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── An opcode in the range 0xC0-0xCF indicates a struct with symbol address field names
 │  ┌─── Field name: FlexUInt 10 ($10)
@@ -1707,7 +1707,7 @@ C6 15 51 01 17 51 02
 ----
 
 .Figure {counter:figure}: Length-prefixed encoding of `_{$10: "variable length struct"}_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
  ┌───────────── Opcode `FC` indicates a variable length struct with symbol address field names
  │  ┌────────── Length: FlexUInt 25
@@ -1743,7 +1743,7 @@ to write a variable-length struct with <<flexsym, `FlexSym`>> field names. The `
 Each field in the struct is encoded as a  <<flexsym, `FlexSym`>> field name, followed by an opcode-prefixed value.
 
 .Figure {counter:figure}: Length-prefixed encoding of `_{"foo": 1, $11: 2}_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌─── Opcode with high nibble `D` indicates a struct with FlexSym field names
 │┌── Length: 9
@@ -1772,7 +1772,7 @@ symbol address field names>> and <<structs_with_flexsym_field_names, structs wit
 delimited structs always use `FlexSym`-encoded field names.
 
 .Figure {counter:figure}: Delimited encoding of the empty struct (`_{}_`)
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌─── Opcode 0xF3 indicates the beginning of a delimited struct with `FlexSym` field names.
 │  ┌─── FlexSym escape code 0x00: an opcode follows
@@ -1782,7 +1782,7 @@ F3 00 F0
 ----
 
 .Figure {counter:figure}: Delimited encoding of `_{"foo": 1, $11: 2}_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌─── Opcode 0xF3 indicates the beginning of a delimited struct with `FlexSym` field names.
 │
@@ -1849,14 +1849,14 @@ All other byte values are reserved for future use.
 NOTE: Future versions of Ion may decide to generalize this into a "constants" table.
 
 .Figure {counter:figure}: Encoding of `_null_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── The opcode `0xEA` represents a null (null.null)
 EA
 ----
 
 .Figure {counter:figure}: Encoding of `_null.string_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── The opcode `0xEB` indicates a typed null; a byte indicating the type follows
 │  ┌──── Byte 0x05 indicates the type `string`
@@ -1891,7 +1891,7 @@ Opcodes `0xE4` through `0xE6` indicate one or more annotations encoded as symbol
 the annotations sequence, which can be made up of any number of `FlexUInt` symbol addresses.
 
 .Figure {counter:figure}: Encoding of `_$10::false_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── The opcode `0xE4` indicates a single annotation encoded as a symbol address follows
 │  ┌──── Annotation with symbol address: FlexUInt 10
@@ -1900,7 +1900,7 @@ E4 15 5F
 ----
 
 .Figure {counter:figure}: Encoding of `_$10::$11::false_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── The opcode `0xE5` indicates that two annotations encoded as symbol addresses follow
 │  ┌──── Annotation with symbol address: FlexUInt 10 ($10)
@@ -1910,7 +1910,7 @@ E5 15 17 5F
 ----
 
 .Figure {counter:figure}: Encoding of `_$10::$11::$12::false_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── The opcode `0xE6` indicates a variable-length sequence of symbol address annotations;
 │     a FlexUInt follows representing the length of the sequence.
@@ -1939,7 +1939,7 @@ symbol addresses>>, it can be slightly less compact when all the annotations are
 addresses.
 
 .Figure {counter:figure}: Encoding of `_$10::false_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── The opcode `0xE7` indicates a single annotation encoded as a FlexSym follows
 │  ┌──── Annotation with symbol address: FlexSym 10 ($10)
@@ -1947,10 +1947,9 @@ E7 15 5F
       └── The annotated value: `false`
 ----
 
-=== Example encoding of `foo::false`
 [source]
 .Figure {counter:figure}: Encoding of `_foo::false_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── The opcode `0xE7` indicates a single annotation encoded as a FlexSym follows
 │  ┌──── Annotation: FlexSym -3; 3 bytes of UTF-8 text follow
@@ -1965,7 +1964,7 @@ Note that `FlexSym` annotation sequences can switch between symbol address and i
 on a per-annotation basis.
 
 .Figure {counter:figure}: Encoding of `_$10::foo::false_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── The opcode `0xE8` indicates two annotations encoded as FlexSyms follow
 │  ┌──── Annotation: FlexSym 10 ($10)
@@ -1978,7 +1977,7 @@ E8 15 FD 66 6F 6F 5F
 ----
 
 .Figure {counter:figure}: Encoding of `_$10::foo::$11::false_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── The opcode `0xE9` indicates a variable-length sequence of FlexSym-encoded annotations
 │  ┌──── Length: FlexUInt 6
@@ -2006,7 +2005,7 @@ annotation sequences or struct field names. If a `NOP` appears in place of a str
 field name is ignored; the `NOP` is immediately followed by the next field name, if any.
 
 .Figure {counter:figure}: Encoding of a 1-byte `_NOP_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── The opcode `0xEC` represents a 1-byte NOP pad
 │
@@ -2014,7 +2013,7 @@ EC
 ----
 
 .Figure {counter:figure}: Encoding of a 4-byte `_NOP_`
-[source,%unbreakable]
+[%unbreakable,source]
 ----
 ┌──── The opcode `0xED` represents a variable-length NOP pad; a FlexUInt length follows
 │  ┌──── Length: FlexUInt 2; two more bytes of NOP follow
@@ -2023,3 +2022,281 @@ ED 05 93 C6
       └─┬─┘
 NOP bytes, values ignored
 ----
+
+[[e_expression_arguments]]
+=== E-expression Arguments
+
+The binary encoding of E-expressions (aka macro invocations) starts with the address of the macro to expand. The address
+can be encoded as <<e_expression_with_the_address_in_the_opcode, part of the opcode>> or as
+<<e_expression_with_the_address_as_a_trailing_flexuint, a `FlexUInt` that follows the opcode>>.
+
+The encoding of the E-expression's arguments depends on their respective types. Argument types can be classified as
+belonging to one of two categories: <<tagged_encodings, _tagged encodings_>> and
+<<tagless_encodings, _tagless encodings_>>.
+
+[[tagged_encodings]]
+==== Tagged Encodings
+
+_Tagged types_ are argument types whose encoding begins with an <<opcodes, opcode>>, sometimes informally called a 'tag'.
+These include the <<core_types, core types>> and the <<abstract_types, abstract types>>.
+
+[[core_types]]
+===== Core types
+
+The _core types_ are the 13 types in the Ion data model:
+
+`null`
+| `bool`
+| `int`
+| `float`
+| `decimal`
+| `timestamp`
+| `string`
+| `symbol`
+| `blob`
+| `clob`
+| `list`
+| `sexp`
+| `struct`
+
+[[abstract_types]]
+===== Abstract types
+
+The _abstract types_ are unions of one or more of the <<core_types, core types>>.
+
+[cols="^.^1a, 6a"]
+|===
+|Abstract type |Included Ion types
+
+|`any`
+|All core Ion types
+
+|`number`
+|`int`, `float`, `decimal`
+
+|`exact`
+|`int`, `decimal`
+
+|`text`
+|`string`, `symbol`
+
+|`lob`
+|`blob`, `clob`
+
+|`sequence`
+|`list`, `sexp`
+|===
+
+===== Tagged E-expression Argument Encoding
+
+When a macro parameter has a tagged type, the encoding of that parameter's corresponding argument in an E-expression
+is identical to how it would be encoded anywhere else in an Ion stream: it has a leading <<opcodes, opcode>> that
+dictates how many bytes follow and how they should be interpreted. This is very flexible, but makes it possible
+for writers to encode values that conflict with the parameter's declared type. Because of this, the macro expander will
+read the argument and then check its type against the parameter's declared type. If it does not match, the macro
+expander must raise an error.
+
+Macro `foo` (defined below) is used in this section's subsequent examples to demonstrate the encoding of tagged-type
+arguments.
+
+.Figure {counter:figure}: Definition of example macro `_foo_` at address 0
+[%unbreakable,source]
+----
+(macro
+    foo           // Macro name
+    [(x number!)] // Parameters
+    /*...*/       // Template (elided)
+)
+----
+
+.Figure {counter:figure}: Encoding of E-expression `_(:foo 9)_`
+[%unbreakable,source]
+----
+┌──── The opcode is less than 0x40, so it is an E-expression invoking the macro at
+│     address 0: `foo`. `foo` takes a tagged number as a parameter (`x`), so an opcode follows.
+│  ┌──── Opcode 0x5B indicates a 2-byte float; an IEEE-754 half-precision float follows
+│  │
+00 5B 42 47
+      └─┬─┘
+      3.14e0
+
+// The macro expander confirms that `3.14e0` (a `float`) matches the expected type: `number`.
+----
+
+.Figure {counter:figure}: Encoding of E-expression `_(:foo 9)_`
+[%unbreakable,source]
+----
+┌──── The opcode is less than 0x40, so it is an E-expression invoking the macro at
+│     address 0: `foo`. `foo` takes a tagged number as a parameter (`x`), so an opcode follows.
+│  ┌──── Opcode 0x51 indicates a 1-byte integer. A 1-byte FixedInt follows.
+│  │  ┌──── A 1-byte FixedInt: 9
+00 51 09
+
+// The macro expander confirms that `9` (an `int`) matches the expected type: `number`.
+----
+
+.Figure {counter:figure}: Encoding of E-expression `_(:foo $10::9)_`
+[%unbreakable,source]
+----
+┌──── The opcode is less than 0x40, so it is an E-expression invoking the macro at
+│     address 0: `foo`. `foo` takes a tagged number as a parameter (`x`), so an opcode follows.
+│  ┌──── Opcode 0xE4 indicates a single annotation with symbol address. A FlexUInt follows.
+│  │  ┌──── Symbol address: FlexUInt 10 ($10); an opcode for the annotated value follows.
+│  │  │  ┌──── Opcode 0x51 indicates a 1-byte integer
+│  │  │  │   ┌──── 1-byte FixedInt 9
+00 E4 15 51 09
+
+// The macro expander confirms that `$10::9` (an annotated `int`) matches the expected type: `number`.
+----
+
+.Figure {counter:figure}: Encoding of E-expression `_(:foo null.int)_`
+[%unbreakable,source]
+----
+┌──── The opcode is less than 0x40, so it is an E-expression invoking the macro at
+│     address 0: `foo`. `foo` takes a tagged number as a parameter (`x`), so an opcode follows.
+│  ┌──── Opcode 0xEB indicates a typed null. A 1-byte FixedUInt follows indicating the type.
+│  │  ┌──── Null type: FixedUInt: 1; integer
+00 EB 01
+
+// The macro expander confirms that `null.int` matches the expected type: `number`.
+----
+
+.Figure {counter:figure}: Encoding of E-expression `_(:foo (:bar))_`
+[%unbreakable,source]
+----
+// A second macro definition at address 1
+(macro
+    bar // Macro name
+    ()  // Parameters
+    5   // Template; invocations of `bar` always expand to `5`.
+)
+
+┌──── The opcode is less than 0x40, so it is an E-expression invoking the macro at
+│     address 0: `foo`. `foo` takes a tagged int as a parameter (`x`), so an opcode follows.
+│  ┌──── Opcode 0x01 is less than 0x40, so it is an E-expression invoking the macro
+│  │     at address 1: `bar`. `bar` takes no parameters, so no bytes follow.
+00 01
+
+// The macro expander confirms that the expansion of `(:bar)` (that is: `5`) matches
+// the expected type: `number`.
+----
+
+.Figure {counter:figure}: Encoding of illegal E-expression `_(:foo "hello")_`
+[%unbreakable,source]
+----
+┌──── The opcode is less than 0x40, so it is an E-expression invoking the macro at
+│     address 0, `foo`. `foo` takes a tagged int as a parameter (`x`), so an opcode follows.
+│  ┌──── Opcode 0x85 indicates a 5-byte string. 5 UTF-8 bytes follow.
+│  │  h  e  l  l  o
+00 83 68 65 6C 6C 6F
+      └──────┬─────┘
+        UTF-8 bytes
+
+// ERROR: Expected a `number` for `foo` parameter `x`, but found `string`
+----
+
+[[tagless_encodings]]
+==== Tagless Encodings
+
+In contrast to <<tagged_encodings, tagged encodings>>, _tagless encodings_ do not begin with an opcode. This means
+that they are potentially more compact than a tagged type, but are also less flexible. Because tagless encodings
+do not have an opcode, they cannot represent E-expressions, annotation sequences, or `null` values of any kind.
+
+Tagless types include the <<primitive_encodings, primitive types>> and <<macro_shapes, macro shapes>>.
+
+[[primitive_encodings]]
+===== Primitive Types
+
+Primitive types are self-delineating, either by having a statically known size in bytes or by including length
+information in their encoding.
+
+Primitive types include:
+
+[cols="^.^1a,^.^2a,^.^1a,^.^4a"]
+|===
+|Ion type |Primitive type |Size in bytes| Encoding
+
+.10+|`int`
+|`uint8`
+|1
+.4+| <<fixeduint, `FixedUInt`>>
+
+|`uint16`
+|2
+
+|`uint32`
+|4
+
+|`uint64`
+|8
+
+|`compact_uint`
+|variable
+|<<flexuint, `FlexUInt`>>
+
+|`int8`
+|1
+.4+| <<fixedint, `FixedInt`>>
+
+|`int16`
+|2
+
+|`int32`
+|4
+
+|`int64`
+|8
+
+|`compact_int`
+|variable
+|<<flexint, `FlexInt`>>
+
+.3+|`float`
+|`float16`
+|2
+|link:https://en.wikipedia.org/wiki/Half-precision_floating-point_format[IEEE-754 half-precision floating point format]
+
+|`float32`
+|4
+|link:https://en.wikipedia.org/wiki/Single-precision_floating-point_format[IEEE-754 single-precision floating point format]
+
+|`float64`
+|8
+|link:https://en.wikipedia.org/wiki/Double-precision_floating-point_format[IEEE-754 double-precision floating point format]
+
+|`symbol`
+|`compact_symbol`
+|variable
+|<<flexsym, `FlexSym`>>
+|===
+
+[sidebar]
+****
+TODO:
+
+* Finalize names for primitive types. (`compact_`? `plain_`?)
+* Do we need a `compact_string` encoding? It saves a byte for string lengths >16 and <128.
+* Do we need other int sizes? `int24`? `int40`?
+****
+
+[[macro_shapes]]
+===== Macro Shapes
+
+The term _macro shape_ describes a macro that is being used as the encoding of an E-expression argument. They are
+considered "shapes" rather than types because while their encoding is always statically known, the types of data
+produced by their expansion is not. A single macro can produce streams of varying length and containing values of
+different Ion types depending on the arguments provided in the invocation.
+
+TODO: Examples
+
+=== Encoding E-expressions With Multiple Arguments
+
+TODO
+
+=== Grouped Parameter Encodings
+
+TODO
+
+=== Voidable Parameter Encodings
+
+TODO

--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -2109,7 +2109,7 @@ arguments.
 )
 ----
 
-.Figure {counter:figure}: Encoding of E-expression `_(:foo 9)_`
+.Figure {counter:figure}: Encoding of E-expression `_(:foo 3.14e)_`
 [%unbreakable,source]
 ----
 ┌──── The opcode is less than 0x40, so it is an E-expression invoking the macro at
@@ -2188,7 +2188,7 @@ arguments.
 │     address 0, `foo`. `foo` takes a tagged int as a parameter (`x`), so an opcode follows.
 │  ┌──── Opcode 0x85 indicates a 5-byte string. 5 UTF-8 bytes follow.
 │  │  h  e  l  l  o
-00 83 68 65 6C 6C 6F
+00 85 68 65 6C 6C 6F
       └──────┬─────┘
         UTF-8 bytes
 


### PR DESCRIPTION
A first pass at an encoding specification for E-expression arguments. This is far from complete; it does not address grouped parameters or voidable parameters, and I intend to add more examples for tagless encodings.

Other changes:
* Swaps out (incorrect) usages of `[source,%unbreakable]` for `[%unbreakable,source]`
* Renames `Opcodes Overview` to just `Opcodes`
* Adds `.idea` to `.gitignore`
* Fixed some erroneous cells in the `Opcodes` table. They referred to low nibble range `A-F`, but should have been `0-F`.
----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
