### PR TITLE
Add more defaulting to macro parameter declarations.

### DIFF
--- a/src/grammar.adoc
+++ b/src/grammar.adoc
@@ -118,20 +118,24 @@ _module-body_ `)`
 
 |signature   |::=|  _param-specs_ _result-spec_?
 |param-specs |::=|  `(` _param-spec_* _rest-spec_? `)`  \|  `[` _param-spec_* _rest-spec_? `]`
-|param-spec  |::=|  _param-name_  \|  _simple-param-spec_  \|  _grouped-param-spec_
+|param-spec  |::=|  _param-name_  \|  `(` _param-name_ _param-shape_ `)`
 |param-name  |::=|  _unannotated-identifier-symbol_
 
-|simple-param-spec  |::=|  `(` _param-name_  _base-shape_ _simple-cardinality_ `)`
-|base-shape         |::=| _tagged-type_  \|  _primitive-type_  \|  _macro-ref_
-|simple-cardinality |::=|  `*!*`  \|  `*+*`  \|  `*'?'*`  \|  `*'{asterisk}'*`
+|param-shape        |::=|  _simple-shape_  \|  _grouped-shape_
 
-|grouped-param-spec  |::=|  `(` _param-name_ `[` _base-shape_ `]` _grouped-cardinality_? `)`
-|grouped-cardinality |::=|  `*+*`  \|  `*'{asterisk}'*`
+|simple-shape       |::=|  _tagless-type_ `*?*`?
+                       \|  _tagged-type_? _any-cardinality_?
+|any-cardinality    |::=|  `*!*`  \|  `*+*`  \|  `*'?'*`  \|  `*'{asterisk}'*`
 
-|rest-spec        |::=|  `(` _param-name_ _base-shape_ _rest-cardinality_  `)`
+|grouped-shape      |::=|   `[` _any-type_? `]` `*+*`?
+
+|rest-spec        |::=|  `(` _param-name_ _any-type_? _rest-cardinality_  `)`
 |rest-cardinality |::=|   `*\...*`  \|  `*\...+*`
 
+|any-type      |::=| _tagged-type_  \|  _tagless-type_
 |tagged-type   |::=| _abstract-type_ \| _concrete-type_
+|tagless-type  |::=| _primitive-type_  \|  _macro-ref_
+
 |abstract-type |::=| `*any*` \| `*number*` \| `*exact*` \| `*text*` \| `*lob*` \| `*sequence*`
 |concrete-type |::=|  `*'null'*`  \|  `*bool*`  \|  `*timestamp*`  \|  `*int*`  \|  `*decimal*`
                   \|  `*float*`  \|  `*string*`  \|  `*symbol*`  \|  `*blob*`  \|  `*clob*`
@@ -143,7 +147,7 @@ _module-body_ `)`
                    \|  `*int8*`     \|  `*int16*`    \|  `*int32*`   \|  `*int64*`
                    \|  `*float16*`  \|  `*float32*`  \|  `*float64*`
 
-|result-spec |::=|  `*\->*` _tagged-type_ _simple-cardinality_
+|result-spec |::=|  `*\->*` _tagged-type_ _any-cardinality_
 |===
 
 

--- a/src/macros-by-example.adoc
+++ b/src/macros-by-example.adoc
@@ -283,14 +283,13 @@ To detect problems close to their source, macro signatures can declare type cons
 [{mrk}]
 ----
 (*macro* detail_page_url
-  [(asin *string* *!*)]
+  [(asin *string*)]
   (website_url (make_string "dp/" asin)))
 ----
 
 This example reveals additional syntax for parameter declarations.  So far, a parameter was
-declared by a symbol denoting its name, now we have an S-expression containing a name, a type,
-and a _cardinality_. Here the parameter's name is `asin`, its type is `string`, and its cardinality
-is `*!*` meaning that a single value is expected.
+declared by a symbol denoting its name, now we have an S-expression containing a name and a type.
+Here the parameter's name is `asin`, its type is `string`.
 The intended input domain is now clear and the Ion parser can emit an error sooner:
 
 [{mrk}]
@@ -300,8 +299,8 @@ The intended input domain is now clear and the Ion parser can emit an error soon
 
 In this context the types include all the normal “concrete” Ion types, abstract
 supertypes like `*number*`, `*text*`, and `*lob*`, and the unconstrained “top type” `*any*`.
-The latter is the default type, and the signature `[foo]` is equivalent to `[(foo *any* *{asterisk}*)]`
-meaning that the parameter `foo` accepts zero or more values of any type.
+The latter is the default type, and the signature `[foo]` is equivalent to `[(foo *any*)]`
+meaning that the parameter `foo` accepts one value of any type.
 
 TIP: These types also serve a second purpose: they can allow the binary encoding to be more compact by
 avoiding type tags or using fixed-width values.
@@ -396,7 +395,7 @@ returns too-few or too-many values.
 
 [{mrk}]
 ----
-(*macro* reverse [(a *any!*), (b *any!*)] // Recall that ! means "exactly one value"
+(*macro* reverse [(a *any*), (b *any*)]
   [b, a])
 ----
 
@@ -487,7 +486,7 @@ created and bound to the next value on the stream.
 [{mrk}]
 ----
 (*macro* prices
-  [(currency *symbol!*), (amounts *number\...*)]
+  [(currency *symbol*), (amounts *number\...*)]
   (*for* [(amt amounts)]                          // <1>
     (price amt currency)))
 ----
@@ -559,7 +558,8 @@ clarity of intent and terminology.
 === Cardinality
 
 As described earlier, parameters are all streams of values, but the number of values can be
-controlled by the parameter's cardinality.  So far we have seen the `*!*` (exactly-one) and `*\...*`
+controlled by the parameter's cardinality.  So far we have seen the default exactly-one
+and the `*\...*`
 (zero-or-more) cardinality modifiers, and in total there are six:
 
 [cols="1,1"]
@@ -577,7 +577,7 @@ controlled by the parameter's cardinality.  So far we have seen the `*!*` (exact
 ==== Exactly-One
 
 Many parameters expect exactly one value and thus have _exactly-one cardinality_.
-We've seen that his is expressed by writing the `*!*` modifier after the parameter type.
+This is the default for ungrouped parameters, but the `*!*` modifier can be used for clarity.
 
 This cardinality means that the parameter requires a stream producing a single value, so one
 might refer to them as _singleton streams_ or just _singletons_ colloquially.
@@ -592,7 +592,7 @@ argument as a way to denote an absent parameter.
 [{mrk}]
 ----
 (*macro* temperature
-  [(degrees *decimal!*), (scale *symbol?*)]
+  [(degrees *decimal*), (scale *symbol?*)]
   {degrees: degrees, scale: scale})
 ----
 
@@ -610,7 +610,7 @@ detect void:
 [{mrk}]
 ----
 (*macro* temperature
-  [(degrees *decimal!*), (scale *symbol?*)]
+  [(degrees *decimal*), (scale *symbol?*)]
   {degrees: degrees, scale: (*if_void* scale (*literal* K) scale)})
 ----
 ----
@@ -642,7 +642,7 @@ just last place.
 [{mrk}]
 ----
 (*macro* prices
-  [(amount *number{asterisk}*), (currency *symbol!*)]
+  [(amount *number{asterisk}*), (currency *symbol*)]
   (*for* [(amt amount)]
     (price amt currency)))
 ----
@@ -667,7 +667,7 @@ the resulting stream must produce at least one value.  To continue using our `pr
 [{mrk}]
 ----
 (*macro* prices
-  [(amount *number+*), (currency *symbol!*)]
+  [(amount *number+*), (currency *symbol*)]
   (*for* [(amt amount)]
     (price amt currency)))
 ----
@@ -715,7 +715,7 @@ applicable sub-expressions.  This is denoted by wrapping the parameter's type in
 ----
 (*macro* prices
   [(amount [*number*]),      // <1>
-   (currency *symbol!*)]
+   (currency *symbol*)]
   (*for* [(amt amount)]
     (price amt currency)))
 ----
@@ -759,13 +759,13 @@ intended to be void or a singleton empty-list value.
 
 Grouping says whether multiple _arguments_ can be provided, while cardinality describes the
 number of _values_ those argument(s) must produce.
-The parameter declaration `(amount [*number*])` makes grouping explicit, but has a default
-cardinality modifier of `*{asterisk}*`.
+The parameter declaration `(amount [*number*])` makes grouping explicit, with a default
+cardinality of zero-or-more.
 The declaration `(amount *[number]+*)` is also valid,
 indicating that the sequence of arguments must produce at least one value.
 
-TIP: Grouped parameters cannot use the `*?*` and `*!*` cardinalities; there's no point in
-requiring a list when no more than one value can be produced.
+TIP: Grouped parameters cannot use the `*?*` and `*!*` modifiers; there's no point in
+requiring a list when no more than one value is allowed.
 
 TIP: Rest parameters are effectively another grouping mode, so they cannot be combined with `[]`.
 
@@ -858,12 +858,12 @@ The following primitive types are available:
 |===
 
 
-To define a tagless parameter, add the `*tagless*` modifier to any of the concrete types:
+To define a tagless parameter, just declare one of the primitive types:
 
 [{mrk}]
 ----
 (*macro* point
-  [(x *var_int!*), (y *var_int!*)]
+  [(x *var_int*), (y *var_int*)]
   {x: x, y: y})
 ----
 ----
@@ -887,7 +887,11 @@ While Ion text syntax doesn’t use tags—the types are built into the syntax�
 that a text E-expression may only express things that can also be expressed using an equivalent
 binary E-expression.
 
-For more impact, use one of the fixed-width types, which are binary-encoded with no per-value
+For the same reasons, tagless types with cardinalities of zero-or-more and one-or-more can only be
+expressed by grouping or rest parameters, not by ungrouped forms.  For example,
+`(v *var_int+*)` and `(v *int32{asterisk}*)` are not accepted.
+
+A subset of the tagless types are _fixed-width_: they are binary-encoded with no per-value
 overhead.
 
 [{mrk}]
@@ -979,15 +983,15 @@ parameter produces a stream of structs.
 The binary encoding of macro-shaped parameters are similarly tagless, eliding any opcodes
 mentioning `point` and just writing its arguments with minimal delimiting.
 
-Macro types can be grouped and/or combined with any cardinality, following the same rules as
-before.  Note that grouped macro shapes require callers to use two layers of delimiting
+Macro types can be grouped and/or combined with cardinality modifiers, following the same rules as
+tagless types.  Note that grouped macro shapes require callers to use two layers of delimiting
 containers: and outer list for the group, and an inner S-expression for
 each macro instance:
 
 [{mrk}]
 ----
 (*macro* scatterplot
-  [(points [point] *+*), (x_label *string!*), (y_label *string!*)]
+  [(points [point] *+*), (x_label *string*), (y_label *string*)]
   { points: [points], x_label: x_label, y_label: y_label })
 ----
 ----
@@ -1018,7 +1022,7 @@ Further, you can't use a macro invocation as an _element_ of the delimiting-list
 This limitation mirrors the binary encoding, where both the delimiting list and the individual
 macro invocations are tagless and there's no way to express a macro invocation.
 
-TIP: The primary goal of macro-shaped arguments, and primitive types in general, is to increase
+TIP: The primary goal of macro-shaped arguments, and tagless types in general, is to increase
 density by tightly constraining the inputs.
 
 

--- a/src/macros-by-example.adoc
+++ b/src/macros-by-example.adoc
@@ -765,7 +765,7 @@ The declaration `(amount *[number]+*)` is also valid,
 indicating that the sequence of arguments must produce at least one value.
 
 TIP: Grouped parameters cannot use the `*?*` and `*!*` modifiers; there's no point in
-requiring a list when no more than one value is allowed.
+requiring a grouping list when no more than one value is allowed.
 
 TIP: Rest parameters are effectively another grouping mode, so they cannot be combined with `[]`.
 
@@ -887,8 +887,8 @@ While Ion text syntax doesn’t use tags—the types are built into the syntax�
 that a text E-expression may only express things that can also be expressed using an equivalent
 binary E-expression.
 
-For the same reasons, tagless types with cardinalities of zero-or-more and one-or-more can only be
-expressed by grouping or rest parameters, not by ungrouped forms.  For example,
+For the same reasons, a parameter accepting more than one tagless argument can only be
+expressed by grouped or rest parameters, not by ungrouped forms.  For example,
 `(v *var_int+*)` and `(v *int32{asterisk}*)` are not accepted.
 
 A subset of the tagless types are _fixed-width_: they are binary-encoded with no per-value
@@ -984,7 +984,7 @@ The binary encoding of macro-shaped parameters are similarly tagless, eliding an
 mentioning `point` and just writing its arguments with minimal delimiting.
 
 Macro types can be grouped and/or combined with cardinality modifiers, following the same rules as
-tagless types.  Note that grouped macro shapes require callers to use two layers of delimiting
+tagless types.  Note that grouped macro types require callers to use two layers of delimiting
 containers: and outer list for the group, and an inner S-expression for
 each macro instance:
 

--- a/src/modules-by-example.adoc
+++ b/src/modules-by-example.adoc
@@ -346,9 +346,9 @@ in full context:
 **$ion_encoding**::(
   (*module* geo
     (*macro_table*
-      (*macro* point [(x *int!*), (y *int!*)]
+      (*macro* point [(x *int*), (y *int*)]
         {x: x, y: y})
-      (*macro* line  [(a *point!*), (b *point!*)]
+      (*macro* line  [(a *point*), (b *point*)]
         [a, b])))
   (*macro_table* geo)
 )
@@ -420,11 +420,11 @@ shared symbol tables, adding a `module` field to hold macro definitions:#
   (*catalog_key* "com.example.graphics.3d" 1)
   (*symbol_table* ["x", "y", "z"])
   (*macro_table*
-    (*macro* point [(x *int!*), (y *int!*), (z *int!*)]
+    (*macro* point [(x *int*), (y *int*), (z *int*)]
       {x: x, y: y, z: z})
-    (*macro* line  [(a *point!*), (b *point!*)]
+    (*macro* line  [(a *point*), (b *point*)]
       [a, b])
-    (*macro* poly  [(first *point!*), (second *point!*), (rest *point\...+*)]
+    (*macro* poly  [(first *point*), (second *point*), (rest *point\...+*)]
       [first, second, rest]))
 )
 ----
@@ -440,11 +440,11 @@ For comparison, here's a functionally-equivalent inline definition:
   (*module* g3d
     (*symbol_table* ["x", "y", "z"])
     (*macro_table*
-      (*macro* point [(x *int!*), (y *int!*), (z *int!*)]
+      (*macro* point [(x *int*), (y *int*), (z *int*)]
         {x: x, y: y, z: z})
-      (*macro* line  [(a *point!*), (b *point!*)]
+      (*macro* line  [(a *point*), (b *point*)]
         [a, b])
-      (*macro* poly  [(first *point!*), (second *point!*), (rest *point\...+*)]
+      (*macro* poly  [(first *point*), (second *point*), (rest *point\...+*)]
         [first, second, rest])))
   ...
 ----
@@ -479,9 +479,9 @@ We can also combine shared and inline modules:
   (*load* g3d "com.example.graphics.3d" 1)
   (*module* geo
     (*macro_table*
-      (*macro* point [(x *int!*), (y *int!*)]
+      (*macro* point [(x *int*), (y *int*)]
         {x: x, y: y})
-      (*macro* line  [(a point**!**), (b point**!**)]
+      (*macro* line  [(a point), (b point)]
         [a, b])))
   (*macro_table* geo g3d)
 )
@@ -533,9 +533,9 @@ First we take our basic geometric macros and package them in a shared module:
 **$ion_shared_module**::$ion_1_1::(
   (*catalog_key* "com.example.geometry" 1)
   (*macro_table*
-    (*macro* point [(x *int!*), (y *int!*)]
+    (*macro* point [(x *int*), (y *int*)]
       {x: x, y: y})
-    (*macro* line  [(a point**!**), (b point**!**)]
+    (*macro* line  [(a point), (b point)]
       [a, b]))
 )
 ----
@@ -630,9 +630,9 @@ You can do similar things within an encoding directive:
 **$ion_encoding**::(
   (*module* geo
     (*macro_table*
-      (*macro* point [(x *int!*), (y *int!*)]
+      (*macro* point [(x *int*), (y *int*)]
         {x: x, y: y})
-      (*macro* line  [(a point**!**), (b point**!**)]
+      (*macro* line  [(a point), (b point)]
         [a, b])))
   (*module* chart
     (*import* geo)                                 // <1>


### PR DESCRIPTION
* The type is optional for both simple and grouped params (defaults to `any`).
* The cardinality is optional for simple params (defaults to `!`).
* Simple tagless params (including macros) can only use `?`, since there's no way to encode more than one value.
* Grouped params can only be modified by `+`.

Changes to the "by Example" chapters are consistent with the grammar, and generally drop use of `!`.  At this point there's no examples using optional-any.

Addresses #230 and #237

### Notes:

This is a draft response to recent suggestions. It doesn't go as far as @zslayton has proposed but leaves room to consider that separately.

I'm becoming inclined to ditch the `!` modifier altogether.  It's only used in conjuction with simple tagged params, it'll probably never be used, and its presence seems to highlight the different default for `[]`.   (I added it for narrative reasons that are now less impactful in the face of grouped parameters.)

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
