### PR TITLE
Fix an uninitialized ION_STRING in the ion-c cookbook samples

### DIFF
--- a/guides/cookbook.md
+++ b/guides/cookbook.md
@@ -1172,7 +1172,8 @@ int main(int argc, char **argv) {
     ION_INT *value_ion_int;
     ION_OK(ion_int_alloc(NULL, &value_ion_int));
     ION_OK(ion_reader_read_ion_int(reader, value_ion_int));
-    ION_STRING istring;
+
+    ION_STRING istring = {0}
     ION_OK(ion_int_to_string(value_ion_int, NULL, &istring));
     char *string_int = ion_string_strdup(&istring);
     printf("    ion_int: %s\n", string_int);
@@ -1602,7 +1603,9 @@ int main(int argc, char **argv) {
 
     ION_OK(ion_reader_close(reader));
 
-    return sum;
+    printf("sum: %d\n", sum);
+
+    return 0;
 }
 ```
 </div>


### PR DESCRIPTION
### Issue #, if available: amazon-ion/ion-c#327

### Description of changes:
The existing example shown for ion-c under the 'Reading numeric types' section used an uninitialized `ION_STRING` that could result in a re-allocation attempt, or stomping of random memory, when calling `ion_int_to_string`.

I went through each of the ion-c examples, and verified that the 'reading numeric types' example was the only example that crashed. While there are some uninitialized `ION_STRING`s in other examples, they are used with ion-c functions that allocate new strings, where `ion_int_to_string` expects an `ION_STRING` to be allocated already.

Another minor issue I found in the examples was the example in the "Performing sparse reads" section. The example calculates a sum by reading ion data, and returns the sum from the main function. This would be interpreted as the program returning an error by the shell.

This PR initializes the `ION_STRING`, and updates the sparse reads example to print out the sum rather than return it.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
