### PR TITLE
Adds the Catalog Best Practices page, linked from the Symbols page in the spec.

### DIFF
--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -1,0 +1,27 @@
+---
+redirect_from: "/catalog.html"
+title: Catalog Best Practices
+description: "The Catalog is user-implemented abstraction that allows Ion readers and writers to resolve shared symbol table imports. This page discusses best practices for Catalog implementers."
+---
+
+# [Docs][docs]/ {{ page.title }}
+
+The Catalog is an abstraction, briefly described in the [specification][symbols], that allows Ion readers and writers to resolve shared symbol table imports. This page discusses best practices for Catalog implementers, and assumes that best practices for shared [symbol table versioning][versioning] are followed. In particular:
+
+> A shared symbol table with version greater than one should usually be a strict extension of the immediately preceding version.
+
+The first step to deciding what kind of Catalog implementation is right for a particular application is to understand that **shared symbol table usage is a contract between the application that produces Ion data and the application(s) that consume that data**. This contract is external to both the Ion specification and to the libraries that implement it. Producing data using shared symbol tables that are not part of the contract, or consuming data without being able to resolve all shared symbol tables included in the contract, may lead to errors in the consuming application.
+
+The simplest way for data producers to ensure their consumers comply with the intended shared symbol table contract is to provide those consumers with a Catalog implementation that complies with that contract. Some example contracts are listed below, alongside a high-level description of the kind of Catalog needed to comply with that contract.
+
+| Contract | Catalog|
+|----------|--------|
+| Data will only ever be encoded with shared symbol table "foo", version 1.| Returns a static view of "foo", version 1 when requested; raises an error if any other table or version is requested.|
+| Data will only ever be encoded with shared symbol table "foo", but the version may change over time.| Contains logic to dynamically resolve different versions of "foo"; returns the version requested or any greater version. Raises an error if any other table is requested.
+| Data may be encoded with any version of any shared symbol table.| Contains logic to dynamically resolve any shared symbol table; returns the version requested or any greater version. Raises an error if the requested table cannot be resolved.
+
+
+<!-- references -->
+[docs]: {{ site.baseurl }}/docs.html
+[symbols]: symbols.html
+[versioning]: symbols.html#versioning

--- a/docs/symbols.md
+++ b/docs/symbols.md
@@ -86,7 +86,7 @@ a static set: one could implement a catalog that pulls symbol tables
 from a network repository, or one that has application symbol tables "compiled
 in", or (very likely) some composition of these techniques. The
 mechanism by which shared symbol tables are acquired is irrelevant to this
-specification.
+specification, but is discussed in [Catalog Best Practices][catalog].
 
 ### Top-Level Semantics
 
@@ -623,3 +623,4 @@ annotations:
 
 <!-- references -->
 [docs]: {{ site.baseurl }}/docs.html
+[catalog]: catalog.html


### PR DESCRIPTION
### Description of changes:

Recently we were made aware of an issue where a producer of binary Ion data began encoding with a new shared symbol table, and a consumer of that data was unable to read it because their catalog implementation was hard-coded to return only the symbol table with which the data had previously been encoded.

The goal of this new "Catalog Best Practices" page is to make it clear that shared symbol table usage is a contract between the application that produces Ion data and the application(s) that consume that data, and to provide high-level guidance for implementing correct Catalog implementations depending on the chosen contract.

Rendered view:
![CBP](https://github.com/amazon-ion/ion-docs/assets/7432835/b33aa346-c4ee-4054-b8e2-04705fa9fae2)

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
