### PR TITLE
Fix doc bug: duplicate section id "macro_shapes"

### DIFF
--- a/src/binary-encoding.adoc
+++ b/src/binary-encoding.adoc
@@ -2298,7 +2298,7 @@ considered "shapes" rather than types because while their encoding is always sta
 produced by their expansion is not. A single macro can produce streams of varying length and containing values of
 different Ion types depending on the arguments provided in the invocation.
 
-See the link:macros-by-example.adoc#macro_shapes[Macro Shapes] section of _Macros by Example_ for more information.
+See the link:macros-by-example.adoc#eg:macro_shapes[Macro Shapes] section of _Macros by Example_ for more information.
 
 === Encoding E-expressions With Multiple Arguments
 

--- a/src/macros-by-example.adoc
+++ b/src/macros-by-example.adoc
@@ -928,7 +928,7 @@ Primitive types have inherent tradeoffs and require careful consideration, but i
 the right circumstances the density wins can be significant.
 
 
-[#macro_shapes]
+[#eg:macro_shapes]
 === Macro Shapes
 
 We can now introduce the final kind of input constraint, macro-shaped parameters.  To understand

--- a/src/modules-by-example.adoc
+++ b/src/modules-by-example.adoc
@@ -524,7 +524,7 @@ in practice, since symbols are trivial to manage.
 Macros are more sophisticated entities, and most macros are implemented in terms of other macros.
 This makes it valuable to support transitive import of macros between shared modules.
 
-Let's revisit <<_macro_shapes,our scatter plot example>> and build a module for expressing charts
+Let's revisit <<eg:macro_shapes,our scatter plot example>> and build a module for expressing charts
 for various data sets.
 First we take our basic geometric macros and package them in a shared module:
 
@@ -813,7 +813,7 @@ Invoked as:
 )
 ----
 
-This leverages <<_splicing_in_encoded_data,splicing>> to add two S-expressions to the enclosing
+This leverages <<eg:splicing,splicing>> to add two S-expressions to the enclosing
 directive.
 
 


### PR DESCRIPTION
Repaired per #257 by adding the `eg:` (examples) prefix.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
