### PR TITLE
Update Docker image to Ubuntu 23.10 (from 22.04).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Inspired by https://github.com/simdjson/simdjson/blob/master/Dockerfile
 
-FROM ubuntu:22.04
+FROM ubuntu:23.10
 
 ARG USER_ID
 ARG GROUP_ID


### PR DESCRIPTION
For some reason, I can no longer build the image on my laptop; it gives a lot of 404 errors for numerous packages.  Updating the base resolved that.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
