### PR TITLE
Replace grouped-parameter lists with new syntax for argument groups.

### DIFF
--- a/src/glossary.adoc
+++ b/src/glossary.adoc
@@ -10,13 +10,15 @@ A macro can be _fixed arity_ or _variable arity_.
 
 argument::
 A single sub-expression within a macro invocation, corresponding to one of the macro’s
-parameters.  This is by default a one-to-one relation, but a parameter’s grouping mode
-can change this to a many-to-one relation.
+parameters.  This is by default a one-to-one relation, but a rest parameter accepts
+zero-or-more or one-or-more arguments.
 
 argument group::
-The concrete syntax for a _grouped parameter_.
-In a macro invocation, a list containing multiple arguments, delimited explicitly with `[...]`
-notation in Ion text. Used to express parameters that accept more than one argument.
+The concrete syntax for passing a stream of values to a macro parameter.
+In a text E-expression, a group starts with the digraph `(:` and ends with `)`,
+similar to an S-expression.
+In the template language, a group is written as an S-expression starting with
+`;` (semicolon).
 
 cardinality::
 Describes the number of values that a parameter will accept when the macro is invoked.
@@ -70,16 +72,6 @@ The number of parameters declared by a macro.  Due to _optional parameters_ and 
 the _actual arity_ of a macro invocation may differ from the formal arity of the macro being
 invoked.
 
-grouped parameter::
-A macro parameter that accepts multiple arguments in an _argument group_ when the macro is
-invoked.
-See also _grouping mode_.
-
-grouping mode::
-One of three ways that a macro parameter is given arguments. A _simple parameter_ accepts one
-argument, a _grouped parameter_ accepts a list of arguments, and a _rest parameter_ accepts
-“all the rest” of the trailing arguments without a grouping list.
-
 Ion version marker::
 A keyword directive that denotes the start of a new segment encoded with a specific Ion version.
 Also known as “IVM”.
@@ -123,7 +115,6 @@ rest parameter::
 A macro parameter—always the final parameter—declared with the `*\...*` or `*\...+*` modifier,
 that accepts all remaining arguments to the macro as if they were in an implicit _argument group_.
 Similar to “varargs” parameters in Java and other languages.
-See also _grouping mode_.
 
 segment::
 A contiguous partition of a document that uses the same encoding environment. Segment boundaries
@@ -134,10 +125,6 @@ signature::
 The part of a macro definition that specifies its “calling convention”, in terms of the shape,
 type, and cardinality of arguments it accepts, and the type and cardinality of the results it
 produces.
-
-simple parameter::
-A macro parameter that matches a single argument when the macro is invoked.
-See also _grouping mode_.
 
 subform::
 A nested portion within some syntactic form of the module or macro declarations.

--- a/src/grammar.adoc
+++ b/src/grammar.adoc
@@ -149,19 +149,10 @@ _module-body_ `)`
 |param-name  |::=|  _unannotated-identifier-symbol_
 // end::signature[]
 // tag::param-shape[]
-|param-shape        |::=|  _simple-shape_  \|  _grouped-shape_
-|simple-shape       |::=|  _tagged-type_? _tagged-cardinality_?    +
-                       \|  _tagless-type_ _tagless-cardinality_?
+|param-shape  |::=|  _any-type_? _cardinality_?
 // end::param-shape[]
 // tag::cardinality[]
-|tagged-cardinality  |::=|  `*!*`  \|  `*+*`  \|  `*'?'*`  \|  `*'{asterisk}'*`
-|tagless-cardinality |::=|  `*'?'*`
-// end::cardinality[]
-// tag::param-shape[]
-|grouped-shape      |::=|   `[` _any-type_? `]` _grouped-cardinality_?
-// end::param-shape[]
-// tag::cardinality[]
-|grouped-cardinality |::=|  `*'+'*`
+|cardinality  |::=|  `*!*`  \|  `*+*`  \|  `*'?'*`  \|  `*'{asterisk}'*`
 // end::cardinality[]
 // tag::param-shape[]
 |rest-shape       |::=|  _any-type_? _rest-cardinality_
@@ -218,7 +209,7 @@ _module-body_ `)`
 |for-clause       |::=| `(` _identifier_ _template~in~_ `)`
 
 |macro-invocation |::=|  `(` _macro-ref_ _macro-arg_* `)`
-|macro-arg        |::=|  _template_  \|  `[` _template_* `]`        // _Very_ roughly
+|macro-arg        |::=|  _template_  \|  `(` `*;*` _template_* `)`    // _Very_ roughly
 
 |===
 // end::templexpr[]

--- a/src/macros-by-example.adoc
+++ b/src/macros-by-example.adoc
@@ -715,7 +715,7 @@ Thank you to my Patreon supporters:
 
 The non-rest versions of multi-value parameters can be annoying to invoke, since they require the
 use of `values` or some other template to produce the stream of values.  To streamline invocation,
-there's a special delimiting syntax for an _argument group_ collecting the
+there is a special delimiting syntax for an _argument group_ collecting the
 applicable sub-expressions.
 
 [{nrm}]

--- a/src/macros-by-example.adoc
+++ b/src/macros-by-example.adoc
@@ -583,7 +583,7 @@ and the `*\...*`
 ==== Exactly-One
 
 Many parameters expect exactly one value and thus have _exactly-one cardinality_.
-This is the default for ungrouped parameters, but the `*!*` modifier can be used for clarity.
+This is the default cardinality, but the `*!*` modifier can be used for clarity.
 
 This cardinality means that the parameter requires a stream producing a single value, so one
 might refer to them as _singleton streams_ or just _singletons_ colloquially.
@@ -711,71 +711,62 @@ Thank you to my Patreon supporters:
 ----
 
 
-[#grouped_parameters]
-=== Grouped Parameters
+=== Argument Groups
 
 The non-rest versions of multi-value parameters can be annoying to invoke, since they require the
 use of `values` or some other template to produce the stream of values.  To streamline invocation,
-a macro can opt-in to special syntax that uses a list as delimiting syntax to group the
-applicable sub-expressions.  This is denoted by wrapping the parameter's type in `[]`:
+there's a special delimiting syntax for an _argument group_ collecting the
+applicable sub-expressions.
 
 [{nrm}]
 ----
 (*macro* prices
-  [(amount [*number*]),      // <1>
+  [(amount *number{asterisk}*),
    (currency *symbol*)]
   (*for* [(amt amount)]
     (price amt currency)))
 ----
 
-<1> Note the use of `[]` around `*number*`.
-
-This is referred to as a _grouped parameter_, and at invocation it requires a list delimiting its
-_argument group_:
+Here, the parameter `amount` accepts any number of `*number*`s.
+It's easy to provide exactly one:
 
 ----
-(:prices [1, 2, 3] GBP) ⇒ {amount:1, currency:GBP}
+(:prices 12.99 GBP) ⇒ {amount:12.99, currency:GBP}
+----
+
+To provide a non-singleton stream of values, use an _argument group_.
+Inside an E-expression, a group starts with the digraph `(:` similar to a macro
+invocation, but without a macro reference:
+
+----
+(:prices (:) GBP)       ⇒ _void_
+(:prices (: 1) GBP)     ⇒ {amount:1, currency:GBP}
+(:prices (: 1 2 3) GBP) ⇒ {amount:1, currency:GBP}
                           {amount:2, currency:GBP}
                           {amount:3, currency:GBP}
 ----
 
-Within the group, the invocation can have any number of arguments, including macro invocations.
+Within the group, the invocation can have any number of expressions that align
+with the parameter type.
 The macro parameter produces the results of those expressions, concatenated into a
 single stream, and the expander verifies that each value on that stream is acceptable by the
 parameter’s declared type.
 
 ----
-(:prices [1, (:values 2 3), 4] GBP) ⇒ {amount:1, currency:GBP}
+(:prices (: 1 (:values 2 3) 4) GBP) ⇒ {amount:1, currency:GBP}
                                       {amount:2, currency:GBP}
                                       {amount:3, currency:GBP}
                                       {amount:4, currency:GBP}
 ----
 
-[IMPORTANT]
-====
-To avoid ambiguity, the delimiter is required even for singleton values.  Consider this
-macro:
+Argument groups are allowed for parameters that do not have exactly-one cardinality.
 
-[{nrm}]
-----
-(*macro* ouch [(stuff [*list*])] …)
-----
+// TODO
+WARNING: The allowed combinations of cardinality and argument groups is pending
+finalization of the binary encoding.
 
-Without this rule, the E-expression `(:ouch [])` would be ambiguous whether the parameter was
-intended to be void or a singleton empty-list value.
-====
-
-Grouping says whether multiple _arguments_ can be provided, while cardinality describes the
-number of _values_ those argument(s) must produce.
-The parameter declaration `(amount [*number*])` makes grouping explicit, with a default
-cardinality of zero-or-more.
-The declaration `(amount *[number]+*)` is also valid,
-indicating that the sequence of arguments must produce at least one value.
-
-TIP: Grouped parameters cannot use the `*?*` and `*!*` modifiers; there's no point in
-requiring a grouping list when no more than one value is allowed.
-
-TIP: Rest parameters are effectively another grouping mode, so they cannot be combined with `[]`.
+TIP: Rest parameters effectively use implicit groups at the call site, and they cannot be
+invoked with explicit groups.
 
 Delimiting sequences and `values` expressions may appear similar because they both denote streams
 of values, but they are not interchangeable:
@@ -799,15 +790,15 @@ generality:
 
 === Optional Arguments
 
-When a trailing parameter is voidable, an invocation can omit its corresponding arguments or
-group, as long as no following parameter is being given an argument or group.  We’ve seen
+When a trailing parameter is voidable, an invocation can omit its corresponding argument expression,
+as long as no following parameter is being given an expression.  We’ve seen
 this as applied to `*\...*` rest-parameters, but it also applies to `*?*` and `*{asterisk}*`
-parameters, with or without groups:
+parameters:
 
 [{nrm}]
 ----
 (*macro* optionals
-  [(a [*any*]), (b *any?*), (c *any!*), (d [*any*]), (e *any?*), (f *any\...*)]
+  [(a *any{asterisk}*), (b *any?*), (c *any!*), (d *any{asterisk}*]), (e *any?*), (f *any\...*)]
   (make_list a b c d e f))
 ----
 
@@ -815,14 +806,14 @@ Since `d`, `e`, and `f` are all voidable, they can be omitted by invokers.  But 
 `a` and `b` must always be present, at least as an empty group:
 
 ----
-(:optionals [] (:) "value for c") ⇒ ["value for c"]
+(:optionals (:) (:) "value for c") ⇒ ["value for c"]
 ----
 
 Now `c` receives the string `"value for c"` while the other parameters are all void.
 If we want to provide `e`, then we must also provide a group for `d`:
 
 ----
-(:optionals [] (:) "value for c" [] "value for e")
+(:optionals (:) (:) "value for c" (:) "value for e")
   ⇒ ["value for c", "value for e"]
 ----
 
@@ -896,9 +887,8 @@ While Ion text syntax doesn’t use tags—the types are built into the syntax�
 that a text E-expression may only express things that can also be expressed using an equivalent
 binary E-expression.
 
-For the same reasons, a parameter accepting more than one tagless argument can only be
-expressed by grouped or rest parameters, not by ungrouped forms.  For example,
-`(v *var_int+*)` and `(v *int32{asterisk}*)` are not accepted.
+For the same reasons, supplying a (non-rest) tagless parameter with no value,
+or with more than one value, can only be expressed by using a group.
 
 A subset of the primitive types are _fixed-width_: they are binary-encoded with no per-value
 overhead.
@@ -993,19 +983,18 @@ parameter produces a stream of structs.
 The binary encoding of macro-shaped parameters are similarly tagless, eliding any opcodes
 mentioning `point` and just writing its arguments with minimal delimiting.
 
-Macro types can be grouped and/or combined with cardinality modifiers, following the same rules as
-tagless types.  Note that grouped macro types require callers to use two layers of delimiting
-containers: and outer list for the group, and an inner S-expression for
-each macro instance:
+Macro types can be combined with cardinality modifiers, with invocations using groups
+as needed.  Note that grouping macro types require callers to use two layers of delimiting
+containers:
 
 [{nrm}]
 ----
 (*macro* scatterplot
-  [(points [point] *+*), (x_label *string*), (y_label *string*)]
+  [(points point *+*), (x_label *string*), (y_label *string*)]
   { points: [points], x_label: x_label, y_label: y_label })
 ----
 ----
-(:scatterplot [(3 17), (395 23), (15 48), (2023 5)] "hour" "widgets")
+(:scatterplot (: (3 17) (395 23) (15 48) (2023 5)) "hour" "widgets")
   ⇒
   {
     points: [{x:3, y:17}, {x:395, y:23}, {x:15, y:48}, {x:2023, y:5}],
@@ -1014,22 +1003,22 @@ each macro instance:
   }
 ----
 
-As with non-macro arguments, you cannot replace a grouping list with a macro invocation.
-Further, you can't use a macro invocation as an _element_ of the delimiting-list:
+As with other tagless parameters, you cannot replace a group with a macro invocation.
+Further, you can't use a macro invocation as an _element_ of the delimiting group:
 
 [{nrm}]
 ----
 (:scatterplot (:make_points 3 17 395 23 15 48 2023 5) "hour" "widgets")
-  ⇒ _**error**: delimiting list or sexp expected, found :make_points_
+  ⇒ _**error**: Argument group expected, found :make_points_
 
-(:scatterplot [(3 17), (:make_points 395 23 15 48), (2023 5)] "hour" "widgets")
+(:scatterplot (: (3 17) (:make_points 395 23 15 48) (2023 5)) "hour" "widgets")
   ⇒ _**error**: sexp expected with args for 'point', found :make_points_
 
-(:scatterplot [(3 17), (:point 395 23), (15 48), (2023 5)] "hour" "widgets")
+(:scatterplot (: (3 17) (:point 395 23) (15 48) (2023 5)) "hour" "widgets")
   ⇒ _**error**: sexp expected with args for 'point', found :point_
 ----
 
-This limitation mirrors the binary encoding, where both the delimiting list and the individual
+This limitation mirrors the binary encoding, where both the delimiting group and the individual
 macro invocations are tagless and there's no way to express a macro invocation.
 
 TIP: The primary goal of macro-shaped arguments, and tagless types in general, is to increase

--- a/src/macros-by-example.adoc
+++ b/src/macros-by-example.adoc
@@ -548,8 +548,8 @@ argument:
 (:pi (:void)) ⇒ _**error**: 'pi' expects 0 arguments, given 1_
 ----
 
-The special-case E-expression `(:)` is synonymous with `(:void)` and is useful as a more succinct
-expression of absent arguments:
+The special form `(:)` is an <<eg:group,empty argument group>>, similar to
+`(:void)` but used specifically to express the absence of an argument:
 
 ----
 (:int_list (:)) ⇒ []
@@ -660,10 +660,13 @@ expression that produces the desired values:
 
 [{nrm}]
 ----
-(:prices (:) JPY)               ⇒ _void_
-(:prices 54 CAD)                ⇒ {amount:54, currency:CAD}
-(:prices (:values 10 9.99) GBP) ⇒ {amount:10, currency:GBP} {amount:9.99, currency:GBP}
+(:prices (:) JPY)          ⇒ _void_
+(:prices 54 CAD)           ⇒ {amount:54, currency:CAD}
+(:prices (: 10 9.99) GBP)  ⇒ {amount:10, currency:GBP} {amount:9.99, currency:GBP}
 ----
+
+Here we use a non-empty <<eg:group,empty argument group>> `(: ...)` to delimit
+the multiple elements of the `amount` stream.
 
 
 ==== One-or-More
@@ -682,8 +685,8 @@ the resulting stream must produce at least one value.  To continue using our `pr
 [{nrm}]
 ----
 (:prices (:) JPY) ⇒ _**error**: at least one value expected for + parameter_
-(:prices 54 CAD)                ⇒ {amount:54, currency:CAD}
-(:prices (:values 10 9.99) GBP) ⇒ {amount:10, currency:GBP} {amount:9.99, currency:GBP}
+(:prices 54 CAD)           ⇒ {amount:54, currency:CAD}
+(:prices (: 10 9.99) GBP)  ⇒ {amount:10, currency:GBP} {amount:9.99, currency:GBP}
 ----
 
 A macro's final parameter can use a variant of rest parameters with one-or-more cardinality,
@@ -711,12 +714,15 @@ Thank you to my Patreon supporters:
 ----
 
 
+[#eg:group]
 === Argument Groups
 
-The non-rest versions of multi-value parameters can be annoying to invoke, since they require the
-use of `values` or some other template to produce the stream of values.  To streamline invocation,
-there is a special delimiting syntax for an _argument group_ collecting the
-applicable sub-expressions.
+The non-rest versions of multi-value parameters require some kind of delimiting
+syntax to contain the applicable sub-expressions.
+For the tagged-type parameters we've seen so far, you _could_ use `:values` or some
+other macro to produce the stream, but that doesn't work for <<tagless,tagless types>>.
+The preferred syntax, supporting all argument types, is a special delimiting form
+called an _argument group_.  Here is a macro to illustrate:
 
 [{nrm}]
 ----
@@ -727,7 +733,7 @@ applicable sub-expressions.
     (price amt currency)))
 ----
 
-Here, the parameter `amount` accepts any number of `*number*`s.
+The parameter `amount` accepts any number of **`number`**s.
 It's easy to provide exactly one:
 
 ----
@@ -738,6 +744,7 @@ To provide a non-singleton stream of values, use an _argument group_.
 Inside an E-expression, a group starts with the digraph `(:` similar to a macro
 invocation, but without a macro reference:
 
+[{nrm}]
 ----
 (:prices (:) GBP)       ⇒ _void_
 (:prices (: 1) GBP)     ⇒ {amount:1, currency:GBP}
@@ -759,7 +766,11 @@ parameter’s declared type.
                                       {amount:4, currency:GBP}
 ----
 
-Argument groups are allowed for parameters that do not have exactly-one cardinality.
+Argument groups may only appear inside macro invocations where the corresponding
+parameter has `*?*`, `*{asterisk}*`, or `*+*` cardinality.
+There is no binary opcode for these constructs; the encoding uses a tagless format to keep
+things as dense as possible.
+As usual, the text format mirrors this constraint.
 
 // TODO
 WARNING: The allowed combinations of cardinality and argument groups is pending
@@ -767,25 +778,6 @@ finalization of the binary encoding.
 
 TIP: Rest parameters effectively use implicit groups at the call site, and they cannot be
 invoked with explicit groups.
-
-Delimiting sequences and `values` expressions may appear similar because they both denote streams
-of values, but they are not interchangeable:
-
-[{nrm}]
-----
-(:prices (:values 10 9.99 12.) GBP) ⇒ _**error**: delimiting list or sexp expected_
-(:prices (:) GBP)                   ⇒ _**error**: delimiting list or sexp expected_
-----
-
-That’s because the binary representation of these parameters uses a tagless format for these
-delimiters to keep the common case as dense as possible. It’s not possible to replace that
-container with a macro invocation, and the text form mirrors that limitation. If the parameter
-type allows (see <<tagless>>), you can call a macro inside the delimiter, with no loss of
-generality:
-
-----
-(:prices [(:values 10)] GBP) ⇒ {amount:10, currency:GBP}
-----
 
 
 === Optional Arguments
@@ -888,7 +880,9 @@ that a text E-expression may only express things that can also be expressed usin
 binary E-expression.
 
 For the same reasons, supplying a (non-rest) tagless parameter with no value,
-or with more than one value, can only be expressed by using a group.
+or with more than one value, can only be expressed by using an argument group.
+
+// TODO: Add examples of non-single cardinality and use of groups.
 
 A subset of the primitive types are _fixed-width_: they are binary-encoded with no per-value
 overhead.
@@ -984,8 +978,7 @@ The binary encoding of macro-shaped parameters are similarly tagless, eliding an
 mentioning `point` and just writing its arguments with minimal delimiting.
 
 Macro types can be combined with cardinality modifiers, with invocations using groups
-as needed.  Note that grouping macro types require callers to use two layers of delimiting
-containers:
+as needed:
 
 [{nrm}]
 ----
@@ -1003,8 +996,8 @@ containers:
   }
 ----
 
-As with other tagless parameters, you cannot replace a group with a macro invocation.
-Further, you can't use a macro invocation as an _element_ of the delimiting group:
+As with other tagless parameters, you cannot replace a group with a macro invocation,
+and you can't use a macro invocation as an _element_ of an argument group:
 
 [{nrm}]
 ----
@@ -1018,7 +1011,7 @@ Further, you can't use a macro invocation as an _element_ of the delimiting grou
   ⇒ _**error**: sexp expected with args for 'point', found :point_
 ----
 
-This limitation mirrors the binary encoding, where both the delimiting group and the individual
+This limitation mirrors the binary encoding, where both the argument group and the individual
 macro invocations are tagless and there's no way to express a macro invocation.
 
 TIP: The primary goal of macro-shaped arguments, and tagless types in general, is to increase

--- a/src/signatures.adoc
+++ b/src/signatures.adoc
@@ -5,7 +5,7 @@ include::styles.adoc[]
 
 A macro's _signature_ defines the syntax of expressions that invoke it, and the set of input values
 it accepts.
-Signatures apply to both E-expressions and macro-language invocations.
+Signatures constrain both E-expressions and macro-language invocations.
 Because they denote the interface for users of macros, we describe them independently of macro
 definitions.
 
@@ -26,10 +26,9 @@ Restricting names to Java-style identifiers enables use of operator characters (
 
 A macro’s “wire format”—the sequence of acceptable tokens in an E-expression—is determined by its
 parameters’ shapes.
-The shape of a parameter has two dimensions: its _base type_ and its grouping.
-The base type constrains the expression forms that can be used for each argument supplied to the
+The base type constrains the syntax that can be used for each argument supplied to the
 parameter.
-Independently, a parameter is either _simple_, _grouped_, or a _rest parameter_; this dimension
+Independently, a parameter is either _simple_ or a _rest parameter_; this dimension
 determines how the arguments supplied to the parameter are delimited within the overall invocation.
 
 [{bnf}]
@@ -113,38 +112,12 @@ Cardinality is verified by the Ion implementation: the expansion system will sig
 error if the number of values produced by the argument(s) is not aligned with the declared
 cardinality.
 
-Some combinations of type and cardinality are inherently erroneous: a primitive type cannot
-produce more than one value.
-
-
-=== Grouped Parameters
-
-A parameter may be _grouped_, in which case its invocation shape is a sequence of arguments.
-In text invocations, this sequence is written as an Ion list containing the arguments.
-In binary E-expressions, the sequence uses a dedicated encoding.
-In all cases, each element of the group must match the parameter’s declared type.
-
-TODO expansion splicing semantics
-
-To declare a grouped parameter, write the parameter specification with a list around the base type.
-Grouped parameters may declare the `+` cardinality, otherwise `*` is implied.
-No other cardinalities are allowed; there’s no point in grouping a parameter that accepts at most
-one value.
-
-Examples:
-
-[{nrm}]
-----
-(counts [int])         // Accepts zero or more ints
-(points [point]+)      // Accepts one or more points
-----
-
 
 === Rest Parameters
 
 The last parameter may be a _rest parameter_, which is effectively an implicitly grouped
 parameter.
-In text invocations, these parameters don’t use a grouping sequence, but instead take “all the
+In text invocations, these parameters don’t use group delimiters, but instead take “all the
 rest” of the argument expressions.
 
 To declare a rest parameter, use one of the two special cardinality modifiers:

--- a/src/template-expr.adoc
+++ b/src/template-expr.adoc
@@ -223,7 +223,8 @@ than the macro’s minimum arity, and at most its maximum arity, when one exists
 In other words, an invocation must contain one subform for each required parameter, followed by
 optional subforms for the remaining optional parameters.
 
-In the template language, argument groups are written by S-expressions starting with the symbol `;`.
+In the template language, argument groups are written by unannoted S-expressions starting with the
+symbol `;`.
 The resulting notation `(; ...)` mirrors the syntax of groups in E-expressions, `(: ...)`.
 
 Within an invocation expression, the syntax of each argument is defined by its parameter’s
@@ -239,11 +240,9 @@ The base types match as follows:
 * For tagged types, the subform may be any template that produces acceptable values.
 * For primitive types, the subform may be any template that produces values accepted by the
 corresponding concrete type.
-* For macro types, the subform must be an S-expression containing subforms acceptable to that
-macro’s signature.  These are implicit invocations of the macro, and the macro name cannot be
+* For macro types, the subform must be an unannotated S-expression containing subforms acceptable to
+that macro’s signature.  These are implicit invocations of the macro, and the macro name cannot be
 provided explicitly.
-
-// NOTE: Removed the ability to explicitly invoke "the same macro".
 
 TODO Clarify when/where range checks are applied for fixed-width types.
 

--- a/src/template-expr.adoc
+++ b/src/template-expr.adoc
@@ -223,12 +223,14 @@ than the macro’s minimum arity, and at most its maximum arity, when one exists
 In other words, an invocation must contain one subform for each required parameter, followed by
 optional subforms for the remaining optional parameters.
 
-Within an invocation expression, the syntax of each subform is defined first by its parameter’s
-grouping form, then its base type:
+In the template language, argument groups are written by S-expressions starting with the symbol `;`.
+The resulting notation `(; ...)` mirrors the syntax of groups in E-expressions, `(: ...)`.
 
-* The subform for a simple parameter must match the base type below.
-* The subform for a grouped parameter must be a list containing elements that each match the base
-type.
+Within an invocation expression, the syntax of each argument is defined by its parameter’s
+declared shape.
+
+* The subform for a non-rest parameter must match the base type below, or an argument group
+containing elements matching the base type.
 * A rest parameter captures all remaining subforms of the invocation, each of which must match
 the base type.
 
@@ -242,8 +244,6 @@ macro’s signature.  These are implicit invocations of the macro, and the macro
 provided explicitly.
 
 // NOTE: Removed the ability to explicitly invoke "the same macro".
-
-TODO Allow macro invocations where grouping list is expected?
 
 TODO Clarify when/where range checks are applied for fixed-width types.
 


### PR DESCRIPTION
The new syntax `(: ...)` denotes an "argument group" and can only occur in an E-expression.  It replaces the use of lists to pass multiple expressions to a single parameter.

"Grouped parameters" are removed from signatures, leaving only cardinality. To use multiple expressions with a parameter, the caller uses an argument group.  A single expression (of appropriate shape) is always acceptable, regardless of cardinality.

In the template language, macro invocations can use the syntax `(; ...)` to denote argument groups.

As you can see from the text changes, this is more simple than the prior syntax and semantics.  It turns grouping into a syntactic concern at the macro invocation site.

### Issue #, if available:

This change is related to #291 but has at least one key difference. As proposed here, argument groups are not general-purpose streams, and can only appear in macro-argument positions.  This is because they have a critical difference from the `values` macro: their contents are shape-constrained by the relevant macro parameter's type, most obviously for macro-shaped parameters.  Personally, I'm in favor of keeping argument groups and `values` invocations syntactically distinct, to reduce confusion.

### Other notes:

* Content explaining when groups are allowed needs to in sync with the binary encoding: text E-expressions should only allow groups where the binary form allows them.
* In editing this I discovered that these docs currently don't have description of text E-expressions; I'll have to circle back and get that content added.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
