### PR TITLE
Clarify Sexp Comment Precedence

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -462,8 +462,6 @@ identifiers can be juxtaposed without whitespace:
 (a==b&&c==d)     // S-expression with seven symbols
 ```
 
-
-
 Note that the data model does not distinguish between identifiers,
 operators, or other symbols, and that -- as always -- the binary format
 does not retain whitespace.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -462,6 +462,8 @@ identifiers can be juxtaposed without whitespace:
 (a==b&&c==d)     // S-expression with seven symbols
 ```
 
+
+
 Note that the data model does not distinguish between identifiers,
 operators, or other symbols, and that -- as always -- the binary format
 does not retain whitespace.
@@ -644,6 +646,15 @@ null.sexp         // A null S-expression value
 
 (a+-b)  ( 'a' '+-' 'b' )    // Equivalent; three symbols
 (a.b;)  ( 'a' '.' 'b' ';')  // Equivalent; four symbols
+```
+
+Note that comments are allowed within S-expressions and have higher precedence
+than operators, therefore `//` and `/*` denote the start of comment blocks. 
+Users are advised to avoid them as operators, though they can be used when
+escaped with single quotes:
+```
+(a/* word */b)       // An S-expression with two symbols and a comment
+(a '/*' word '*/' b) // An S-expression with five symbols
 ```
 
 Although Ion S-expressions use a syntax similar to Lisp expressions, Ion does


### PR DESCRIPTION
Add clarifying note that comments take precedence over operators in S-expressions.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
