### PR TITLE
Remove `...` and `...+` cardinalities from the bulk of the document.

### DIFF
--- a/src/eexprs.adoc
+++ b/src/eexprs.adoc
@@ -78,10 +78,10 @@ individual argument.
 * A `?` parameter accepts either a single individual argument
   or an empty argument group `(:)`.
 * A `*` or `+` parameter accepts either a single individual argument,
-  or an argument group `(: …)`.
-* A rest parameter captures all remaining arguments of the E-expression,
-  each of which must match the individual argument syntax.
-  For a `...+` parameter there must be at least one such argument.
+  a group `(: …)` of individual arguments, or, if in final position, all
+  remaining arguments of the E-expression.
+  For a `+` parameter there must be at least one individual argument, grouped or
+  not.
 
 // TODO clarify whether a `+` group must contain at least one element.
 

--- a/src/eexprs.adoc
+++ b/src/eexprs.adoc
@@ -77,7 +77,7 @@ individual argument.
 * A `!` parameter accepts only a single individual argument.
 * A `?` parameter accepts either a single individual argument
   or an empty argument group `(:)`.
-* A `*` or `+` parameter accepts either a single individual argument,
+* A `*` or `\+` parameter accepts either a single individual argument,
   a group `(: …)` of individual arguments, or, if in final position, all
   remaining arguments of the E-expression.
   For a `+` parameter there must be at least one individual argument, grouped or

--- a/src/glossary.adoc
+++ b/src/glossary.adoc
@@ -115,8 +115,8 @@ required parameter::
 A macro parameter that is not _optional_ and therefore requires an argument at each invocation.
 
 rest parameter::
-A macro parameter—always the final parameter—declared with the `*\...*` or `*\...+*` modifier,
-that accepts all remaining arguments to the macro as if they were in an implicit _argument group_.
+A macro parameter—always the final parameter—declared with `*` or `+` cardinality,
+that accepts all remaining individual arguments to the macro as if they were in an implicit _argument group_.
 Similar to “varargs” parameters in Java and other languages.
 
 segment::

--- a/src/grammar.adoc
+++ b/src/grammar.adoc
@@ -143,9 +143,8 @@ _module-body_ `)`
 // end::macro-defn[]
 // tag::signature[]
 |signature   |::=|  _param-specs_ _result-spec_?
-|param-specs |::=|  `(` _param-spec_* _rest-spec_? `)`  \|  `[` _param-spec_* _rest-spec_? `]`
+|param-specs |::=|  `(` _param-spec_* `)`  \|  `[` _param-spec_* `]`
 |param-spec  |::=|  _param-name_  \|  `(` _param-name_ _param-shape_ `)`
-|rest-spec   |::=|  `(` _param-name_ _rest-shape_  `)`
 |param-name  |::=|  _unannotated-identifier-symbol_
 // end::signature[]
 // tag::param-shape[]
@@ -153,12 +152,6 @@ _module-body_ `)`
 // end::param-shape[]
 // tag::cardinality[]
 |cardinality  |::=|  `*!*`  \|  `*+*`  \|  `*'?'*`  \|  `*'{asterisk}'*`
-// end::cardinality[]
-// tag::param-shape[]
-|rest-shape       |::=|  _any-type_? _rest-cardinality_
-// end::param-shape[]
-// tag::cardinality[]
-|rest-cardinality |::=|   `*\...*`  \|  `*\...+*`
 // end::cardinality[]
 // tag::param-types[]
 |any-type      |::=| _tagged-type_  \|  _tagless-type_

--- a/src/macros-by-example.adoc
+++ b/src/macros-by-example.adoc
@@ -11,7 +11,7 @@ moving parts without getting into the weeds of more formal specification.
 
 Ion macros are defined using a domain-specific language that is in turn expressed via the Ion
 data model. That is, macro definitions are Ion data, and use Ion features like S-expressions and
-symbols to represent code in a LISP-like fashion.  In this document, the fundamental construct we
+symbols to represent code in a Lisp-like fashion.  In this document, the fundamental construct we
 explore is the _macro definition_, denoted using an S-expression of the form `(*macro* _name_ …)`
 where `*macro*` is a keyword and `_name_` must be a symbol denoting the macro's name.
 
@@ -324,14 +324,14 @@ To make this work, the definition of make_string is effectively:
 
 [{nrm}]
 ----
-(*macro* make_string [(parts *text \...*)] …)
+(*macro* make_string [(parts *text {asterisk}*)] …)
 ----
 
 This says that `parts` is a _rest parameter_ accepting zero or more arguments of type `*text*`.
-The `*\...*` modifier can only occur on the last parameter, declaring that “all the rest” of the
-arguments will be passed to that one name.
+The `*{asterisk}*` cardinality modifier, when applied to a final parameter, declares that
+“all the rest” of the arguments will be passed to that one name.
 
-NOTE: The Ion grammar treats identifiers like `text` and operators like `\...` as separate tokens
+NOTE: The Ion grammar treats identifiers like `text` and operators like `*` as separate tokens
 regardless of whether they are separated by whitespace.  We think it's easier to read without
 whitespace and will use that convention from now on.
 
@@ -341,7 +341,7 @@ twenty, or none. We describe the acceptable number of values for a parameter as 
 _cardinality_.  In the examples so far, all parameters have had _exactly-one_ cardinality, while
 `parts` has _zero-or-more_ cardinality.  We’ll see additional cardinalities soon!
 
-TIP: To declare a rest parameter that requires at least one value, use the `*\...+*` modifier.
+TIP: To declare a final parameter that requires at least one rest-argument, use the `*+*` modifier.
 
 
 === Arguments and Results are Streams
@@ -359,7 +359,7 @@ We have everything we need to illustrate this, via another system macro, `values
 
 [{nrm}]
 ----
-(*macro* values [(vals *any\...*)] vals)
+(*macro* values [(vals *any{asterisk}*)] vals)
 ----
 
 [{nrm}]
@@ -453,10 +453,10 @@ list:
 [{nrm}]
 ----
 (*macro* int_list
-  [(vals **int\...**)]
+  [(vals **int{asterisk}**)]
   [ vals ])
 (*macro* clumsy_bag
-  [(elts **any\...**)]
+  [(elts **any{asterisk}**)]
   { '': elts })
 ----
 ----
@@ -487,7 +487,7 @@ created and bound to the next value on the stream.
 [{nrm}]
 ----
 (*macro* prices
-  [(currency *symbol*), (amounts *number\...*)]
+  [(currency *symbol*), (amounts *number{asterisk}*)]
   (*for* [(amt amounts)]                          // <1>
     (price amt currency)))
 ----
@@ -529,7 +529,7 @@ https://github.com/amazon-ion/ion-docs/issues/201
 
 The empty stream is an important edge case that requires careful handling and communication.
 We'll use the term _void_ to mean “empty stream”.  We’ll even mint the word _voidable_ to
-describe parameters that can accept empty streams, like the ``*\...*``s above.
+describe parameters that can accept empty streams, like the ``*{asterisk}*``s above.
 
 Correspondingly, the built-in macro `void` accepts no values and produces an empty stream:
 
@@ -564,8 +564,7 @@ clarity of intent and terminology.
 
 As described earlier, parameters are all streams of values, but the number of values can be
 controlled by the parameter's cardinality.  So far we have seen the default exactly-one
-and the `*\...*`
-(zero-or-more) cardinality modifiers, and in total there are six:
+and the `*{asterisk}*` (zero-or-more) cardinality modifiers, and in total there are four:
 
 [cols="1,1"]
 |===
@@ -574,8 +573,6 @@ and the `*\...*`
 | `*?*`     |zero-or-one value
 | `*+*`     |one-or-more values
 | `***`     |zero-or-more values
-| `*\...*`  |zero-or-more values, as "rest" arguments
-| `*\...+*` |one-or-more values, as "rest" arguments
 |===
 
 
@@ -642,9 +639,7 @@ To refine things a bit further, trailing voidable arguments can be omitted entir
 [#eg:zero-or-more]
 ==== Zero-or-More
 
-A parameter with the modifier `***` has _zero-or-more cardinality_.  This modifier behaves the
-same as `*\...*` from the perspective of its template, but it can be used in any position, not
-just last place.
+A parameter with the modifier `***` has _zero-or-more cardinality_.
 
 [{nrm}]
 ----
@@ -654,8 +649,9 @@ just last place.
     (price amt currency)))
 ----
 
-The calling convention for `***` is different from `*\...*` since the “all the rest”
-convention can’t be used to draw the boundaries of the stream.  Instead, we need a single
+When `*{asterisk}*` is on a non-final parameter, we cannot take the “all the rest” of the arguments
+and must use a different calling convention to draw the boundaries of the stream.
+Instead, we need a single
 expression that produces the desired values:
 
 [{nrm}]
@@ -671,7 +667,7 @@ the multiple elements of the `amount` stream.
 
 ==== One-or-More
 
-A parameter with the modifier `*+*` has _one-or-more cardinality_, which works like `***` except
+A parameter with the modifier `*+*` has _one-or-more cardinality_, which works like `*{asterisk}*` except
 the resulting stream must produce at least one value.  To continue using our `prices` example:
 
 [{nrm}]
@@ -689,12 +685,11 @@ the resulting stream must produce at least one value.  To continue using our `pr
 (:prices (: 10 9.99) GBP)  ⇒ {amount:10, currency:GBP} {amount:9.99, currency:GBP}
 ----
 
-A macro's final parameter can use a variant of rest parameters with one-or-more cardinality,
-denoted by the `*\...+*` modifier:
+On the final parameter, `*+*` collects the remaining (one or more) arguments:
 
 [{nrm}]
 ----
-(*macro* thanks [(names *text\...+*)]
+(*macro* thanks [(names *text+*)]
   (make_string "Thank you to my Patreon supporters:\n"
     (for [(n names)]
       (make_string "  * " n "\n"))))
@@ -702,7 +697,7 @@ denoted by the `*\...+*` modifier:
 
 [{nrm}]
 ----
-(:thanks) ⇒ _**error**: at least one value expected for \...+ parameter_
+(:thanks) ⇒ _**error**: at least one value expected for + parameter_
 
 (:thanks Larry Curly Moe) =>
 '''\
@@ -776,21 +771,18 @@ As usual, the text format mirrors this constraint.
 WARNING: The allowed combinations of cardinality and argument groups is pending
 finalization of the binary encoding.
 
-TIP: Rest parameters effectively use implicit groups at the call site, and they cannot be
-invoked with explicit groups.
-
 
 === Optional Arguments
 
 When a trailing parameter is voidable, an invocation can omit its corresponding argument expression,
 as long as no following parameter is being given an expression.  We’ve seen
-this as applied to `*\...*` rest-parameters, but it also applies to `*?*` and `*{asterisk}*`
+this as applied to final `*{asterisk}*` parameters, but it also applies to `*?*`
 parameters:
 
 [{nrm}]
 ----
 (*macro* optionals
-  [(a *any{asterisk}*), (b *any?*), (c *any!*), (d *any{asterisk}*]), (e *any?*), (f *any\...*)]
+  [(a *any{asterisk}*), (b *any?*), (c *any!*), (d *any{asterisk}*]), (e *any?*), (f *any{asterisk}*)]
   (make_list a b c d e f))
 ----
 
@@ -890,7 +882,7 @@ overhead.
 [{nrm}]
 ----
 (*macro* byte_array
-  [(bytes *uint8\...*)]
+  [(bytes *uint8{asterisk}*)]
   [bytes])
 ----
 
@@ -936,7 +928,7 @@ can go is `*struct*`, and things aren’t really any better:
 
 [{nrm}]
 ----
-(*macro* scatterplot [(points *struct\...*)]
+(*macro* scatterplot [(points *struct{asterisk}*)]
   [points])
 ----
 ----
@@ -955,7 +947,7 @@ pseudo-type:
 
 [{nrm}]
 ----
-(*macro* scatterplot [(points point**\...**)]  // <1>
+(*macro* scatterplot [(points point*)]  // <1>
   [points])
 ----
 

--- a/src/modules-by-example.adoc
+++ b/src/modules-by-example.adoc
@@ -348,7 +348,7 @@ in full context:
     (*macro_table*
       (*macro* point [(x *int*), (y *int*)]
         {x: x, y: y})
-      (*macro* line  [(a *point*), (b *point*)]
+      (*macro* line  [(a point), (b point)]
         [a, b])))
   (*macro_table* geo)
 )
@@ -422,9 +422,9 @@ shared symbol tables, adding a `module` field to hold macro definitions:#
   (*macro_table*
     (*macro* point [(x *int*), (y *int*), (z *int*)]
       {x: x, y: y, z: z})
-    (*macro* line  [(a *point*), (b *point*)]
+    (*macro* line  [(a point), (b point)]
       [a, b])
-    (*macro* poly  [(first *point*), (second *point*), (rest *point\...+*)]
+    (*macro* poly  [(first point), (second point), (rest point+)]
       [first, second, rest]))
 )
 ----
@@ -442,9 +442,9 @@ For comparison, here's a functionally-equivalent inline definition:
     (*macro_table*
       (*macro* point [(x *int*), (y *int*), (z *int*)]
         {x: x, y: y, z: z})
-      (*macro* line  [(a *point*), (b *point*)]
+      (*macro* line  [(a point), (b point)]
         [a, b])
-      (*macro* poly  [(first *point*), (second *point*), (rest *point\...+*)]
+      (*macro* poly  [(first point), (second point), (rest point+)]
         [first, second, rest])))
   ...
 ----
@@ -549,7 +549,7 @@ Now we build another shared module using it:
   (*load* geo "com.example.geometry" 1)   // <1>
   (*macro_table*
     (*macro* scatterplot
-      [(points ':geo:point'**\...**)]        // <2>
+      [(points ':geo:point'*)]          // <2>
       [points]))
 )
 ----
@@ -571,7 +571,7 @@ just the `geo` module but also its macros, via `*use*`:
   (*catalog_key* "com.example.charts" 1)
   (*use* (*load* geo "com.example.geometry" 1))   // <1>
   (*macro_table*
-    (*macro* scatterplot [(points point**\...**)]    // <2>
+    (*macro* scatterplot [(points point*)]      // <2>
       [points]))
 )
 ----
@@ -637,7 +637,7 @@ You can do similar things within an encoding directive:
   (*module* chart
     (*import* geo)                                 // <1>
     (*macro_table*
-      (*macro* scatterplot [(points point**\...**)]
+      (*macro* scatterplot [(points point*)]
         [points])))
   (*macro_table* chart)                            // <2>
 )
@@ -662,7 +662,7 @@ import both the 2d and 3d modules:
     (*import* geo "com.example.geometry" 1)
     (*import* g3d "com.example.graphics.3d" 1)
     (*macro_table*
-      (*macro* scatterplot [(points point**\...**)]
+      (*macro* scatterplot [(points point*)]
 
   ⇒ **error**: 'point' is ambiguous, exported by 'geo' and 'g3d'.
 ----
@@ -673,7 +673,7 @@ smile syntax does not apply.  Instead, use a quoted symbol:
 
 [{nrm}]
 ----
-      (*macro* scatterplot [(points ':geo:point' **\...**)]
+      (*macro* scatterplot [(points ':geo:point' *)]
         [points]))
 ----
 
@@ -687,7 +687,7 @@ A more ergonomic approach is to introduce an alias to disambiguate:
     (*import* g3d "com.example.graphics.3d" 1)
     (*alias* point2 ':geo:point')                 // <1>
     (*macro_table*
-      (*macro* scatterplot [(points point2 **\...**)]  // <2>
+      (*macro* scatterplot [(points point2*)]  // <2>
         [points])
       ...
 ----
@@ -795,7 +795,7 @@ If we find this particularly bothersome, a macro can eliminate the repetition:
 
 [{nrm}]
 ----
-(*macro* both_tables [(module_names *symbol\...*)]
+(*macro* both_tables [(module_names *symbol{asterisk}*)]
   (values
     (make_sexp (*literal* symbol_table) module_names)
     (make_sexp (*literal* macro_table ) module_names)))

--- a/src/signatures.adoc
+++ b/src/signatures.adoc
@@ -26,10 +26,8 @@ Restricting names to Java-style identifiers enables use of operator characters (
 
 A macro’s “wire format”—the sequence of acceptable tokens in an E-expression—is determined by its
 parameters’ shapes.
-The base type constrains the syntax that can be used for each argument supplied to the
+The parameter type and cardinality constrain the syntax that can be used for each argument supplied to the
 parameter.
-Independently, a parameter is either _simple_ or a _rest parameter_; this dimension
-determines how the arguments supplied to the parameter are delimited within the overall invocation.
 
 [{bnf}]
 |===
@@ -96,6 +94,8 @@ their type, since that’s implied by context.
 Each parameter specification includes a _cardinality_ that indicates the number of values that it
 expects its argument(s) to produce.
 
+TODO: Cardinality also affects the number of individual arguments accepted
+
 [{bnf}]
 |===
 include::grammar.adoc[tag=cardinality]
@@ -113,47 +113,26 @@ error if the number of values produced by the argument(s) is not aligned with th
 cardinality.
 
 
-=== Rest Parameters
-
-The last parameter may be a _rest parameter_, which is effectively an implicitly grouped
-parameter.
-In text invocations, these parameters don’t use group delimiters, but instead take “all the
-rest” of the argument expressions.
-
-To declare a rest parameter, use one of the two special cardinality modifiers:
-
-* `\...` denotes a parameter that accepts zero or more values.
-* `\...+` denotes a parameter that accepts one or more values.
-
-Examples:
-
-[{nrm}]
-----
-(counts int \...)      // Accepts zero or more ints
-(points point \...+)   // Accepts one or more points
-----
-
-
 === Arity: Required and Optional Parameters
 
 [[def:optional-param]]
-Parameters with cardinality accepting zero values (declared with modifiers `?`, `*`, or `\...`)
+Parameters with cardinality accepting zero values (declared with modifiers `?` or `*`)
 are called _voidable_ because their resulting value streams can be void.
 A parameter is _optional_ when it is voidable and all following parameters are voidable.
 
 [[def:required-param]]
 A parameter is _required_ when it is not optional.
 Specifically, a parameter is required when it is declared with modifiers
-`!`, `\+`, or `...+`, _or_ when any following parameter is required.
+`!` or `+`, _or_ when any following parameter is required.
 
 Optional parameters are given special treatment in text invocations: their arguments can be
 omitted entirely, as long as all following arguments are also omitted.
 
 [[def:arity]]
 The _minimum arity_ of a macro is equal to the number of leading non-optional parameters.
-Assuming no rest-parameter, the _maximum arity_ of the macro is the total number of declared
-parameters.
-A macro with a rest-parameter has no maximum arity.
+The _maximum arity_ of the macro is the total number of declared
+parameters, unless the final parameter is declared `*` or `+` in which case
+the macro has no maximum arity.
 A macro with equal minimum and maximum arity is _fixed arity_; other templates are _variable
 arity_.
 

--- a/src/system-module.adoc
+++ b/src/system-module.adoc
@@ -42,7 +42,7 @@ To make such use more readable, the special-case E-expression `(:)` is synonymou
 
 [{nrm}]
 ----
-(values (v any\...)) \-> any*
+(values (v any*)) \-> any*
 ----
 
 Produces a stream from any number of arguments, concatenating the streams produced by the nested
@@ -57,7 +57,7 @@ multiple results. Generally only useful with more than one subexpression.
 
 [{nrm}]
 ----
-(make_string (content text\...)) \-> string
+(make_string (content text*)) \-> string
 ----
 
 Produces a non-null, unannotated string containing the concatenated content produced by the
@@ -73,7 +73,7 @@ as characters. Lobs wouldn’t work well, though.
 
 [{nrm}]
 ----
-(make_symbol (content text\...)) \-> symbol
+(make_symbol (content text*)) \-> symbol
 ----
 
 Like `make_string` but produces a symbol.
@@ -83,7 +83,7 @@ Like `make_string` but produces a symbol.
 
 [{nrm}]
 ----
-(make_list (vals any\...)) \-> list
+(make_list (vals any*)) \-> list
 ----
 
 Produces a non-null, unannotated list from any number of inputs.
@@ -94,7 +94,7 @@ Template expressions of the form `[E~1~, …, E~n~]` are equivalent to `(make_li
 
 [{nrm}]
 ----
-(make_sexp (vals any\...)) \-> sexp
+(make_sexp (vals any*)) \-> sexp
 ----
 
 Like `make_list` but produces a sexp.
@@ -112,7 +112,7 @@ templates are not <<ref:quasi-literals, quasi-literals>>.
 
 [{nrm}]
 ----
-(make_struct (kv any\...)) \-> struct
+(make_struct (kv any*)) \-> struct
 ----
 
 Produces a non-null, unannotated struct from any number of elements.
@@ -204,7 +204,7 @@ Example:
 
 [{nrm}]
 ----
-(annotate (ann [text]*) value) \-> any
+(annotate (ann text*) value) \-> any
 ----
 
 Produces the `value` prefixed with the annotations ``ann``s.
@@ -212,7 +212,7 @@ Each `ann` must be a non-null, unannotated string or symbol.
 
 [{nrm}]
 ----
-(:annotate ["a2"] a1::true) => a2::a1::true
+(:annotate "a2" a1::true) => a2::a1::true
 ----
 
 
@@ -233,7 +233,7 @@ This macro is optimized for representing symbols-list with minimal space.
   { name:name, version:version, max_id:max_id })
 
 (*macro* local_symtab
-  \((imports [import]) (symbols string**\...**))
+  \((imports import*) (symbols string*))
   $ion_symbol_table::{
     imports:(*if_void* imports (void) [imports]),
     symbols:(*if_void* symbols (void) [symbols]),
@@ -242,7 +242,7 @@ This macro is optimized for representing symbols-list with minimal space.
 
 [{nrm}]
 ----
-(:local_symtab [("my.symtab" 4)] "newsym" "another")
+(:local_symtab ("my.symtab" 4) (: "newsym" "another"))
   =>
   $ion_symbol_table::{ imports:[{name:"my.symtab", version:4}],
                        symbols:["newsym", "another"] }
@@ -254,7 +254,7 @@ This macro is optimized for representing symbols-list with minimal space.
 [{nrm}]
 ----
 (*macro* lst_append
-  \((symbols string\...))
+  \((symbols string*))
   (*if_void* symbols
     (void)                  // Produce nothing if no symbols provided.
     $ion_symbol_table::{

--- a/src/template-expr.adoc
+++ b/src/template-expr.adoc
@@ -245,11 +245,11 @@ Each element of an argument group must fit the same syntax rules as for an
 individual argument.
 The resulting notation `(; ...)` mirrors the syntax of groups in E-expressions, `(: ...)`.
 
-* A non-rest parameter of any cardinality accepts either a single individual argument
+* A parameter of any cardinality accepts either a single individual argument
   or an argument group.
-* A rest parameter captures all remaining arguments of the invocation,
+* A final `*` or `+` parameter alternatively captures all remaining arguments of the invocation,
   each of which must match the individual argument syntax.
-  For a `...+` parameter there must be at least one such argument.
+  For a final `+` parameter there must be at least one such argument.
 
 These rules determine whether a template macro invocation is _well-formed_.
 Any violation of the above constraints must signal a syntax error when the


### PR DESCRIPTION
Note that the binary encoding chapter still needs updating for this as well as the prior removal of grouped parameters.

### Description of changes:

Updated the spec to remove the bespoke rest cardinalities; "rest parameter" is now an optional, implicit capability of final `*` and `+` parameters.

The "Macros by Example" chapter should probably be revisited and rearranged to account for this. Currently, it introduces `...` long before cardinality as a concept, which at the time felt like an easier order to introduce things.  Now that rest-parameters isn't a separate concept from cardinality, things would probably flow better introducing cardinality early on, then rest invocations later.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
