### PR TITLE
Specify that `for` clauses must define at least one local variable.

### DIFF
--- a/src/grammar.adoc
+++ b/src/grammar.adoc
@@ -197,7 +197,7 @@ _module-body_ `)`
                  \|  `(` `*if_void*`   _template~cond~_ _template~then~_ _template~else~_ `)`  +
                  \|  `(` `*if_single*` _template~cond~_ _template~then~_ _template~else~_ `)`  +
                  \|  `(` `*if_multi*`  _template~cond~_ _template~then~_ _template~else~_ `)`  +
-                 \|  `(` `*for*` `[` _for-clause_* `]` _template~body~_ `)`
+                 \|  `(` `*for*` `[` _for-clause_+ `]` _template~body~_ `)`
 
 |for-clause       |::=| `(` _identifier_ _template~in~_ `)`
 

--- a/src/template-expr.adoc
+++ b/src/template-expr.adoc
@@ -182,7 +182,7 @@ These special forms produce repeated output mapped across elements of a stream.
 
 [{nrm}]
 ----
-(*for* [(_id_ _template~in~_), ...] _template~body~_)
+(*for* [(_id_ _template~in~_), ...+] _template~body~_)
 ----
 
 Iteratively expands the _template~body~_ using individual values from the _in-templates_.
@@ -192,6 +192,9 @@ stream ends.
 Local variables are created for each identifier _id_, bound to the current value from their stream.
 The _template~body~_ is then expanded in that environment, and iteration proceeds.
 The result of the `*for*` expression is the concatenated results of the body expansions.
+
+It is a compile-time error if a `for` expression does not define any variables,
+as in `(*for* [] 1)`.
 
 NOTE: The termination rule is under discussion; see
 https://github.com/amazon-ion/ion-docs/issues/201


### PR DESCRIPTION
This avoids surprises, and sidesteps making sense of `(for null.list ...)`.

### Description of changes:

For comparison, Racket's `for` runs the body once when no variables are introduced. That has the benefit that the result is always determined by the body (as opposed to some default defined by `for`), and that the whole thing isn't effectively no-op, but could also be surprising to users.

Since I personally see no need to support a no-variable option, and since we also need to handle degenerate invocations that don't have actual lists in that position, I prefer to require at least one variable and input stream.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
