### PR TITLE
Update documentation links for ion-go and ion-rust

### DIFF
--- a/_data/libraries.json
+++ b/_data/libraries.json
@@ -30,7 +30,8 @@
     "name": "ion-rust",
     "category": "core",
     "latest_release_version": "1.0.0-rc.6",
-    "latest_release_date": "2024-06-06"
+    "latest_release_date": "2024-06-06",
+    "documentation": "https://docs.rs/ion-rs/latest/ion_rs/"
   },
   {
     "name": "ion-python",
@@ -44,7 +45,7 @@
     "category": "core",
     "latest_release_version": "1.5.0",
     "latest_release_date": "2024-06-06",
-    "documentation": "https://pkg.go.dev/github.com/amzn/ion-go/ion"
+    "documentation": "https://pkg.go.dev/github.com/amazon-ion/ion-go/ion"
   },
   {
     "name": "ion-java-path-extraction",


### PR DESCRIPTION
### Issue #, if available: n/a

### Description of changes:
This PR updates the documentation link for:
*  ion-go - The documentation link includes the github path, which needed to be updated to include the amazon-ion org change.
* ion-rust - The documentation link was added to point to the latest crates.io entry.




----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
