### PR TITLE
Fix deploy workflow for news release commits

### DIFF
--- a/.github/workflows/release-news.yml
+++ b/.github/workflows/release-news.yml
@@ -18,6 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          # This is needed so that the deploy workflow will be triggered for news release commits.
+          # See https://github.com/orgs/community/discussions/26220
+          persist-credentials: false
 
       - name: Generate News Posts
         id: generate_news


### PR DESCRIPTION
### Issue #, if available:

None.

### Description of changes:

When the news release workflow pushes a commit, it doesn't trigger the `deploy` workflow. As it turns out, there is an obscure limitation where if you use the checkout action with a particular access token and then push using that token, it doesn't trigger any "on push" workflows (c.f. https://github.com/orgs/community/discussions/25702). A workaround is given in [this GitHub discussion](https://github.com/orgs/community/discussions/26220#discussioncomment-3250853), which I am adding to the release news workflow.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
