### PR TITLE
Make release news workflow trigger the deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,8 @@ permissions:
   pages: write
 
 on:
+  # Allow manual starting of this workflow, including using `gh workflow run` in the release news workflow
+  workflow_dispatch:
   push:
     branches: [ gh-pages ]
 

--- a/.github/workflows/release-news.yml
+++ b/.github/workflows/release-news.yml
@@ -18,11 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          # This is needed so that the deploy workflow will be triggered for news release commits.
-          # See https://github.com/orgs/community/discussions/26220
-          persist-credentials: false
-
       - name: Generate News Posts
         id: generate_news
         shell: bash
@@ -38,3 +33,14 @@ jobs:
           git config user.email github-actions@github.com
           git commit -m "${{ steps.generate_news.outputs.generated_commit_message }}"
           git push
+
+      - name: Deploy Changes
+        if: ${{ steps.generate_news.outputs.changes > 0 }}
+        # If you use the GITHUB_TOKEN to push code, it won't trigger any on-push
+        # workflows, so we manually the workflow here.
+        # We can't just call the workflow directly because we need the workflow to run
+        # on the new commit, not the GITHUB_REF for this workflow.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run .github/workflows/deploy.yml -R "${{ github.repository }}"


### PR DESCRIPTION
### Issue #, if available:

None

### Description of changes:

Fixes the release news workflow so that it can push changes and trigger the deploy workflow.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
