### PR TITLE
System module hex codes

### DIFF
--- a/_books/ion-1-1/src/modules/system_module.md
+++ b/_books/ion-1-1/src/modules/system_module.md
@@ -32,106 +32,105 @@ The Ion 1.1 System Symbol table _replaces_ rather than extends the Ion 1.0 Syste
 <!-- make the tables align to the side of the page /-->
 <style>table { margin: 1em;}</style>
 
-| ID | Text                           |
-|---:|:-------------------------------|
-|  0 | _&lt;reserved&gt;_             |
-|  1 | `$ion`                         |
-|  2 | `$ion_1_0`                     |
-|  3 | `$ion_symbol_table`            |
-|  4 | `name`                         |
-|  5 | `version`                      |
-|  6 | `imports`                      |
-|  7 | `symbols`                      |
-|  8 | `max_id`                       |
-|  9 | `$ion_shared_symbol_table`     |
-| 10 | `$ion_encoding`                |
-| 11 | `$ion_literal`                 |
-| 12 | `$ion_shared_module`           |
-| 13 | `macro`                        |
-| 14 | `macro_table`                  |
-| 15 | `symbol_table`                 |
-| 16 | `module`                       |
-| 17 | see [ion-docs#345][1]          |
-| 18 | `export`                       |
-| 19 | see [ion-docs#345][1]          |
-| 20 | `import`                       |
-| 21 | _zero-length text_ (i.e. `''`) |
-| 22 | `literal`                      |
-| 23 | `if_none`                      |
-| 24 | `if_some`                      |
-| 25 | `if_single`                    |
-| 26 | `if_multi`                     |
-| 27 | `for`                          |
-| 28 | `default`                      |
-| 29 | `values`                       |
-| 30 | `annotate`                     |
-| 31 | `make_string`                  |
-| 32 | `make_symbol`                  |
-| 33 | `make_blob`                    |
-| 34 | `make_decimal`                 |
-| 35 | `make_timestamp`               |
-| 36 | `make_list`                    |
-| 37 | `make_sexp`                    |
-| 38 | `make_struct`                  |
-| 39 | `parse_ion`                    |
-| 40 | `repeat`                       |
-| 41 | `delta`                        |
-| 42 | `flatten`                      |
-| 43 | `sum`                          |
-| 44 | `set_symbols`                  |
-| 45 | `add_symbols`                  |
-| 46 | `set_macros`                   |
-| 47 | `add_macros`                   |
-| 48 | `use`                          |
-| 49 | `meta`                         |
-| 50 | `flex_symbol`                  |
-| 51 | `flex_int`                     |
-| 52 | `flex_uint`                    |
-| 53 | `uint8`                        |
-| 54 | `uint16`                       |
-| 55 | `uint32`                       |
-| 56 | `uint64`                       |
-| 57 | `int8`                         |
-| 58 | `int16`                        |
-| 59 | `int32`                        |
-| 60 | `int64`                        |
-| 61 | `float16`                      |
-| 62 | `float32`                      |
-| 63 | `float64`                      |
-| 64 | `none`                         |
-| 65 | `make_field`                   |
-
+| ID | Hex  | Text                           |
+|---:|:----:|:-------------------------------|
+|  0 | 0x00 | _&lt;reserved&gt;_             |
+|  1 | 0x01 | `$ion`                         |
+|  2 | 0x02 | `$ion_1_0`                     |
+|  3 | 0x03 | `$ion_symbol_table`            |
+|  4 | 0x04 | `name`                         |
+|  5 | 0x05 | `version`                      |
+|  6 | 0x06 | `imports`                      |
+|  7 | 0x07 | `symbols`                      |
+|  8 | 0x08 | `max_id`                       |
+|  9 | 0x09 | `$ion_shared_symbol_table`     |
+| 10 | 0x0A | `$ion_encoding`                |
+| 11 | 0x0B | `$ion_literal`                 |
+| 12 | 0x0C | `$ion_shared_module`           |
+| 13 | 0x0D | `macro`                        |
+| 14 | 0x0E | `macro_table`                  |
+| 15 | 0x0F | `symbol_table`                 |
+| 16 | 0x10 | `module`                       |
+| 17 | 0x11 | see [ion-docs#345][1]          |
+| 18 | 0x12 | `export`                       |
+| 19 | 0x13 | see [ion-docs#345][1]          |
+| 20 | 0x14 | `import`                       |
+| 21 | 0x15 | _zero-length text_ (i.e. `''`) |
+| 22 | 0x16 | `literal`                      |
+| 23 | 0x17 | `if_none`                      |
+| 24 | 0x18 | `if_some`                      |
+| 25 | 0x19 | `if_single`                    |
+| 26 | 0x1A | `if_multi`                     |
+| 27 | 0x1B | `for`                          |
+| 28 | 0x1C | `default`                      |
+| 29 | 0x1D | `values`                       |
+| 30 | 0x1E | `annotate`                     |
+| 31 | 0x1F | `make_string`                  |
+| 32 | 0x20 | `make_symbol`                  |
+| 33 | 0x21 | `make_blob`                    |
+| 34 | 0x22 | `make_decimal`                 |
+| 35 | 0x23 | `make_timestamp`               |
+| 36 | 0x24 | `make_list`                    |
+| 37 | 0x25 | `make_sexp`                    |
+| 38 | 0x26 | `make_struct`                  |
+| 39 | 0x27 | `parse_ion`                    |
+| 40 | 0x28 | `repeat`                       |
+| 41 | 0x29 | `delta`                        |
+| 42 | 0x2A | `flatten`                      |
+| 43 | 0x2B | `sum`                          |
+| 44 | 0x2C | `set_symbols`                  |
+| 45 | 0x2D | `add_symbols`                  |
+| 46 | 0x2E | `set_macros`                   |
+| 47 | 0x2F | `add_macros`                   |
+| 48 | 0x30 | `use`                          |
+| 49 | 0x31 | `meta`                         |
+| 50 | 0x32 | `flex_symbol`                  |
+| 51 | 0x33 | `flex_int`                     |
+| 52 | 0x34 | `flex_uint`                    |
+| 53 | 0x35 | `uint8`                        |
+| 54 | 0x36 | `uint16`                       |
+| 55 | 0x37 | `uint32`                       |
+| 56 | 0x38 | `uint64`                       |
+| 57 | 0x39 | `int8`                         |
+| 58 | 0x3A | `int16`                        |
+| 59 | 0x3B | `int32`                        |
+| 60 | 0x3C | `int64`                        |
+| 61 | 0x3D | `float16`                      |
+| 62 | 0x3E | `float32`                      |
+| 63 | 0x3F | `float64`                      |
+| 64 | 0x40 | `none`                         |
+| 65 | 0x41 | `make_field`                   |
 In Ion 1.1 Text, system symbols can never be referenced by symbol ID; `$1` always refers to the first symbol in the user symbol table.
 This allows the Ion 1.1 system symbol table to be relatively large without taking away SID space from the user symbol table.
 
 ### System Macros
 
-| ID | Text                                                          |
-|---:|:--------------------------------------------------------------|
-|  0 | [`none`](../macros/system_macros.md#none)                     |
-|  1 | [`values`](../macros/system_macros.md#values)                 |
-|  2 | [`annotate`](../macros/system_macros.md#annotate)             |
-|  3 | [`make_string`](../macros/system_macros.md#make_string)       |
-|  4 | [`make_symbol`](../macros/system_macros.md#make_symbol)       |
-|  5 | [`make_blob`](../macros/system_macros.md#make_blob)           |
-|  6 | [`make_decimal`](../macros/system_macros.md#make_decimal)     |
-|  7 | [`make_timestamp`](../macros/system_macros.md#make_timestamp) |
-|  8 | [`make_list`](../macros/system_macros.md#make_list)           |
-|  9 | [`make_sexp`](../macros/system_macros.md#make_sexp)           |
-| 10 | [`make_struct`](../macros/system_macros.md#make_struct)       |
-| 11 | [`set_symbols`](../macros/system_macros.md#set_symbols)       |
-| 12 | [`add_symbols`](../macros/system_macros.md#add_symbols)       |
-| 13 | [`set_macros`](../macros/system_macros.md#set_macros)         |
-| 14 | [`add_macros`](../macros/system_macros.md#add_macros)         |
-| 15 | [`use`](../macros/system_macros.md#use)                       |
-| 16 | [`parse_ion`](../macros/system_macros.md#parse_ion)           |
-| 17 | [`repeat`](../macros/system_macros.md#repeat)                 |
-| 18 | [`delta`](../macros/system_macros.md#delta)                   |
-| 19 | [`flatten`](../macros/system_macros.md#flatten)               |
-| 20 | [`sum`](../macros/system_macros.md#sum)                       |
-| 21 | [`meta`](../macros/system_macros.md#meta)                     |
-| 22 | [`make_field`](../macros/system_macros.md#make_field)         |
-| 22 | [`default`](../macros/system_macros.md#default)               |
+| ID | Hex  | Text                                                          |
+|---:|:----:|:--------------------------------------------------------------|
+|  0 | 0x00 | [`none`](../macros/system_macros.md#none)                     |
+|  1 | 0x01 | [`values`](../macros/system_macros.md#values)                 |
+|  2 | 0x02 | [`annotate`](../macros/system_macros.md#annotate)             |
+|  3 | 0x03 | [`make_string`](../macros/system_macros.md#make_string)       |
+|  4 | 0x04 | [`make_symbol`](../macros/system_macros.md#make_symbol)       |
+|  5 | 0x05 | [`make_blob`](../macros/system_macros.md#make_blob)           |
+|  6 | 0x06 | [`make_decimal`](../macros/system_macros.md#make_decimal)     |
+|  7 | 0x07 | [`make_timestamp`](../macros/system_macros.md#make_timestamp) |
+|  8 | 0x08 | [`make_list`](../macros/system_macros.md#make_list)           |
+|  9 | 0x09 | [`make_sexp`](../macros/system_macros.md#make_sexp)           |
+| 10 | 0x0A | [`make_struct`](../macros/system_macros.md#make_struct)       |
+| 11 | 0x0B | [`set_symbols`](../macros/system_macros.md#set_symbols)       |
+| 12 | 0x0C | [`add_symbols`](../macros/system_macros.md#add_symbols)       |
+| 13 | 0x0D | [`set_macros`](../macros/system_macros.md#set_macros)         |
+| 14 | 0x0E | [`add_macros`](../macros/system_macros.md#add_macros)         |
+| 15 | 0x0F | [`use`](../macros/system_macros.md#use)                       |
+| 16 | 0x10 | [`parse_ion`](../macros/system_macros.md#parse_ion)           |
+| 17 | 0x11 | [`repeat`](../macros/system_macros.md#repeat)                 |
+| 18 | 0x12 | [`delta`](../macros/system_macros.md#delta)                   |
+| 19 | 0x13 | [`flatten`](../macros/system_macros.md#flatten)               |
+| 20 | 0x14 | [`sum`](../macros/system_macros.md#sum)                       |
+| 21 | 0x15 | [`meta`](../macros/system_macros.md#meta)                     |
+| 22 | 0x16 | [`make_field`](../macros/system_macros.md#make_field)         |
+| 22 | 0x17 | [`default`](../macros/system_macros.md#default)               |
 
 
 ----

--- a/_books/ion-1-1/src/modules/system_module.md
+++ b/_books/ion-1-1/src/modules/system_module.md
@@ -131,7 +131,7 @@ This allows the Ion 1.1 system symbol table to be relatively large without takin
 | 20 | 0x14 | [`sum`](../macros/system_macros.md#sum)                       |
 | 21 | 0x15 | [`meta`](../macros/system_macros.md#meta)                     |
 | 22 | 0x16 | [`make_field`](../macros/system_macros.md#make_field)         |
-| 22 | 0x17 | [`default`](../macros/system_macros.md#default)               |
+| 23 | 0x17 | [`default`](../macros/system_macros.md#default)               |
 
 
 ----

--- a/_books/ion-1-1/src/modules/system_module.md
+++ b/_books/ion-1-1/src/modules/system_module.md
@@ -100,6 +100,7 @@ The Ion 1.1 System Symbol table _replaces_ rather than extends the Ion 1.0 Syste
 | 63 | 0x3F | `float64`                      |
 | 64 | 0x40 | `none`                         |
 | 65 | 0x41 | `make_field`                   |
+
 In Ion 1.1 Text, system symbols can never be referenced by symbol ID; `$1` always refers to the first symbol in the user symbol table.
 This allows the Ion 1.1 system symbol table to be relatively large without taking away SID space from the user symbol table.
 


### PR DESCRIPTION
### Issue #, if available: N/A

### Description of changes: When I stare at a hexdump, these are the values I see. Now I can look them up directly, and don't have to do the math. 

In the process I noticed that the system macro code 22 occurs twice, so I changed `default` to be ID 23 as looks like was likely the intent. 

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
