### PR TITLE
Update float.md links

### DIFF
--- a/docs/float.md
+++ b/docs/float.md
@@ -108,6 +108,6 @@ the following text forms all map to the same `binary64` value:
 
 <!-- References -->
 [docs]: {{ site.baseurl }}/docs.html
-[rounding]: http://ampl.com/REFS/rounding.pdf
-[clinger]: http://www.cesura17.net/~will/professional/research/papers/howtoread.pdf
-[printing-fp]: http://www.cs.indiana.edu/~dyb/pubs/FP-Printing-PLDI96.pdf
+[rounding]: https://ampl.com/_archive/first-website/REFS/rounding.pdf
+[clinger]: https://dl.acm.org/doi/10.1145/93548.93557
+[printing-fp]: https://dl.acm.org/doi/10.1145/231379.231397


### PR DESCRIPTION
### Issue #, if available:

None

### Description of changes:

The link for Clinger's algorithm was broken, and the other links had permanent redirects. I have updated two of the references to point to the ACM page for that paper (available for free as PDF and EPUB). For the "Correctly Rounded Binary-Decimal and Decimal-Binary Conversions" paper, I was unable to find a better source since only the abstract seems to be available on the Bell Labs website (see [here](https://www.bell-labs.com/institute/publications/bl9100445/)), and it's not available from ACM, arXiv, or IEEE Xplore. I'll try to determine whether we can host a copy of it on our own website so that we're not in danger of the link breaking for that one.

<!--  Gay DM, Correctly rounded binary-decimal and decimal-binary conversions; 1990. AT&T Bell Laboratories Numerical Analysis Manuscript 90-10. -->

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
