### PR TITLE
Adds missing space in macros_by_example.md

### DIFF
--- a/_books/ion-1-1/src/macros/macros_by_example.md
+++ b/_books/ion-1-1/src/macros/macros_by_example.md
@@ -127,7 +127,7 @@ Template expressions that are structs are interpreted _almost_ literally;
 the field names are literal--is why the `amount` and `currency` field names show up as-is in the expansion--but the field “values” are arbitrary expressions.
 We call these almost-literal forms _quasi-literals_.
 
-The template definition language also treats lists quasi-literally, and every element inside the list is anexpression.
+The template definition language also treats lists quasi-literally, and every element inside the list is an expression.
 Here’s a silly macro to illustrate:
 
 ```ion


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:

Adds a missing space. `anexpression` to `an expression`

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
