### PR TITLE
Makes minor fixes to the binary sections; adds an explanation for the opcode 0xF5 (length-prefixed e-expression).

### DIFF
--- a/_books/ion-1-1/src/binary/annotations.md
+++ b/_books/ion-1-1/src/binary/annotations.md
@@ -9,7 +9,7 @@ It is illegal for an annotations sequence to appear before any of the following:
 * The end of the stream
 * Another annotations sequence
 * A [`NOP`](nop.md)
-* An e-expression. To add annotations to the _expansion_ of an E-expression, see [the `annotate` macro](../todo.md).
+* An e-expression. To add annotations to the _expansion_ of an E-expression, see [the `annotate` macro](../macros/system_macros.md#annotate).
 
 
 ### Annotations With Symbol Addresses

--- a/_books/ion-1-1/src/binary/e_expressions.md
+++ b/_books/ion-1-1/src/binary/e_expressions.md
@@ -2,7 +2,7 @@
 ## Encoding Expressions
 
 > [!NOTE]
-> This chapter focuses on the binary encoding of e-expressions. [_Macros by example_](../macros/macros_by_example.md) explains what they are and how they are used.
+> This chapter focuses on the binary encoding of e-expressions. The [_Macros_](../macros.md) section explains what they are and how they are used.
 
 ### E-expression with the address in the opcode
 
@@ -28,8 +28,8 @@ corresponding __address__—-an offset within the local macro table.
 ```
 
 Note that the opcode alone tells us which macro is being invoked, but it does not supply enough information for the
-reader to parse any arguments that may follow. The parsing of arguments is described in detail in the section _Macro
-calling conventions_. (TODO: Link)
+reader to parse any arguments that may follow. The parsing of arguments is described in detail in the section
+[_E-expression argument encoding_](#e-expression-argument-encoding).
 
 #### E-expressions with biased `FixedUInt` addresses
 
@@ -98,8 +98,8 @@ Address : 142918
 #### E-expression with the address as a trailing `FlexUInt`
 
 The opcode `0xF4` indicates an e-expression whose address is encoded as a trailing [`FlexUInt`](primitives/flex_uint.md) with no bias.
-This encoding is less compact for addresses that can be encoded using opcodes `0x5F` and below, but it is the
-only encoding that can be used for macro addresses greater than 1,052,734.
+This encoding is less compact for addresses that can be encoded using opcodes `0x5F` and below, but it is one of only two opcodes,
+along with `0xF5`, that can be used for macro addresses greater than 1,052,734.
 
 ##### Invocation of macro address `4`
 ```
@@ -121,6 +121,37 @@ F4 04 47 86
       └─── FlexUInt 1,100,000
 ```
 
+#### E-expression with the address as a `FlexUInt` and length as a trailing `FlexUInt`
+
+The opcode `0xF5` indicates an e-expression whose address is encoded as a [`FlexUInt`](primitives/flex_uint.md) with no bias,
+followed by a `FlexUInt` that represents the length in bytes of the remainder of the expression. Although this encoding is less
+compact than other e-expression encodings, it allows for readers to quickly seek to the end of the expression if the user requires
+only partial evaluation.
+
+##### Invocation of macro address `4` with two tagged arguments
+```
+┌──── Opcode F5 indicates an e-expression with a `FlexUInt` macro address followed by a `FlexUInt` length
+│
+│
+F5 09 07 60 61 01
+   │   │  │ └─┬─┘
+   │   │  │   └─ Tagged integer 1
+   │   │  └─ Tagged integer 0
+   │   └─ FlexUInt 3 (the remaining length of the expression)
+   └─── FlexUInt 4 (the macro address)
+```
+
+##### Invocation of macro address `1_100_000` with no arguments
+```
+┌──── Opcode F5 indicates an e-expression with a `FlexUInt` macro address followed by a `FlexUInt` length
+│
+│
+F5 04 47 86 01
+   └──┬───┘ │
+      │     └─ FlexUInt 0 (the remaining length of the expression)
+      └─── FlexUInt 1,100,000 (the macro address)
+```
+
 ### System Macro Invocations
 
 E-expressions that invoke a [system macro](../modules/system_module.md#system-macros) can be encoded using the `0xEF` opcode followed by a 1-byte `FixedUInt` representing an index in the [system macro table](../modules/system_module.md#system-macros).
@@ -134,7 +165,7 @@ EF 01
 ```
 
 In addition, system macros MAY be invoked using any of the `0x00`-`0x5F` or `0xF4`-`0xF5` opcodes, provided that the macro being invoked has been given an address in user macro address space.
-<!-- TODO: Add or link an example of how this can be done. /-->
+For more information about managing the macro address space, see the [_Modules_](../modules.md) section.
 
 ## E-expression argument encoding
 
@@ -239,7 +270,7 @@ F4 01 61 01 61 02 61 03
 
 ### Tagless Encodings
 
-In contrast to the [`tagged encoding`](#tagged-encoding), _tagless encodings_ do not begin with an opcode.
+In contrast to the [tagged encoding](#tagged-encoding), _tagless encodings_ do not begin with an opcode.
 This means that they are potentially more compact than a tagged type, but are also less flexible. Because tagless encodings
 do not have an opcode, they cannot represent E-expressions, annotation sequences, or `null` values of any kind.
 
@@ -253,14 +284,14 @@ information in their serialized form.
 | Ion type | Primitive encoding | Size in bytes | Encoding                                                                                                              |
 |----------|--------------------|:-------------:|-----------------------------------------------------------------------------------------------------------------------|
 | `int`    | `uint8`            |       1       | [`FixedUInt`](primitives/fixed_uint.md)                                                                               |
-|          | `uint16`           |       2       |                                                                                                                       |
-|          | `uint32`           |       4       |                                                                                                                       |
-|          | `uint64`           |       8       |                                                                                                                       |
+|          | `uint16`           |       2       | [`FixedUInt`](primitives/fixed_uint.md)                                                                               |
+|          | `uint32`           |       4       | [`FixedUInt`](primitives/fixed_uint.md)                                                                               |
+|          | `uint64`           |       8       | [`FixedUInt`](primitives/fixed_uint.md)                                                                               |
 |          | `flex_uint`        |   variable    | [`FlexUInt`](primitives/flex_uint.md)                                                                                 |
 |          | `int8`             |       1       | [`FixedInt`](primitives/fixed_int.md)                                                                                 |
-|          | `int16`            |       2       |                                                                                                                       |
-|          | `int32`            |       4       |                                                                                                                       |
-|          | `int64`            |       8       |                                                                                                                       |
+|          | `int16`            |       2       | [`FixedInt`](primitives/fixed_int.md)                                                                                 |
+|          | `int32`            |       4       | [`FixedInt`](primitives/fixed_int.md)                                                                                 |
+|          | `int64`            |       8       | [`FixedInt`](primitives/fixed_int.md)                                                                                 |
 |          | `flex_int`         |   variable    | [`FlexInt`](primitives/flex_int.md)                                                                                   |
 | `float`  | `float16`          |       2       | [Little-endian IEEE-754 half-precision float](https://en.wikipedia.org/wiki/Half-precision_floating-point_format)     |
 |          | `float32`          |       4       | [Little-endian IEEE-754 single-precision float](https://en.wikipedia.org/wiki/Single-precision_floating-point_format) |
@@ -445,7 +476,7 @@ As noted in the table above:
 #### Expression groups
 
 This section describes the encoding of an expression group. For an explanation of what an expression group is and how to use it,
-see _[Expression groups](../todo.md)_.
+see [_Argument groups_](../macros/macros_by_example.md#argument-groups).
 
 An expression group begins with a [`FlexUInt`](primitives/flex_uint.md). If the `FlexUInt`'s value
 is:

--- a/_books/ion-1-1/src/binary/encoding.md
+++ b/_books/ion-1-1/src/binary/encoding.md
@@ -1,7 +1,7 @@
 # Ion 1.1 Binary Encoding
 
-A binary Ion stream consists of an [_Ion version marker_](todo.md) followed by a series of
+A binary Ion stream consists of an [_Ion version marker_](../glossary.md) followed by a series of
 [value literals](values.md) and/or [encoding expressions](e_expressions.md).
 
-Both value literals and e-expressions begin with an [opcode](opcode.md) that indicates
+Both value literals and e-expressions begin with an [opcode](opcodes.md) that indicates
 what the next expression represents and how the bytes that follow should be interpreted.

--- a/_books/ion-1-1/src/binary/nop.md
+++ b/_books/ion-1-1/src/binary/nop.md
@@ -4,7 +4,7 @@ A `NOP` (short for "no-operation") is the binary equivalent of whitespace. `NOP`
 but can be used as padding to achieve a desired alignment.
 
 An opcode of `0xEC` indicates a single-byte `NOP` pad. An opcode of `0xED` indicates that a
-[`FlexUInt`](#flexuint) follows that represents the number of additional bytes to skip.
+[`FlexUInt`](primitives/flex_uint.md) follows that represents the number of additional bytes to skip.
 
 It is legal for a `NOP` to appear anywhere that a [value](values.md) can be encoded. It is not legal for a `NOP` to appear in
 annotation sequences or struct field names. If a `NOP` appears in place of a struct field _value_, then the associated

--- a/_books/ion-1-1/src/binary/opcodes.md
+++ b/_books/ion-1-1/src/binary/opcodes.md
@@ -5,47 +5,47 @@ and how the bytes that follow should be interpreted.
 
 The meanings of each opcode are organized loosely by their high and low nibbles.
 
-| High nibble      | Low nibble | Meaning                                              |
-|------------------|------------|------------------------------------------------------|
-| `0x0_` to `0x3_` | `0`-`F`    | E-expression with 6-bit address                      |
-| `0x4_`           | `0`-`F`    | E-expression with 12-bit address                     |
-| `0x5_`           | `0`-`F`    | E-expression with 20-bit address                     |
-| `0x6_`           | `0`-`8`    | Integers from 0 to 8 bytes wide                      |
-|                  | `9`        | _Reserved_                                           |
-|                  | `A`-`D`    | Floats                                               |
-|                  | `E`-`F`    | Booleans                                             |
-| `0x7_`           | `0`-`F`    | Decimals                                             |
-| `0x8_`           | `0`-`C`    | Short-form timestamps                                |
-|                  | `D`-`F`    | _Reserved_                                           |
-| `0x9_`           | `0`-`F`    | Strings                                              |
-| `0xA_`           | `0`-`F`    | Symbols with inline text                             |
-| `0xB_`           | `0`-`F`    | Lists                                                |
-| `0xC_`           | `0`-`F`    | S-expressions                                        |
-| `0xD_`           | `0`        | Empty struct                                         |
-|                  | `1`        | _Reserved_                                           |
-|                  | `2`-`F`    | Structs                                              |
-| `0xE_`           | `0`        | Ion version marker                                   |
-|                  | `1`-`3`    | Symbols with symbol address                          |
-|                  | `4`-`6`    | Annotations with symbol address                      |
-|                  | `7`-`9`    | Annotations with `FlexSym` text                      |
-|                  | `A`        | `null.null`                                          |
-|                  | `B`        | Typed nulls                                          |
-|                  | `C`-`D`    | NOP                                                  |
-|                  | `E`        | System symbol                                        |
-|                  | `F`        | System macro invocation                              |
-| `0xF_`           | `0`        | Delimited container end                              |
-|                  | `1`        | Delimited list start                                 |
-|                  | `2`        | Delimited S-expression start                         |
-|                  | `3`        | Delimited struct start                               |
-|                  | `4`        | E-expression with `FlexUInt` macro address           |
-|                  | `5`        | E-expression with `FlexUInt` length prefix           |
-|                  | `6`        | Integer with `FlexUInt` length prefix                |
-|                  | `7`        | Decimal with `FlexUInt` length prefix                |
-|                  | `8`        | Timestamp with `FlexUInt` length prefix              |
-|                  | `9`        | String with `FlexUInt` length prefix                 |
-|                  | `A`        | Symbol with `FlexUInt` length prefix and inline text |
-|                  | `B`        | List with `FlexUInt` length prefix                   |
-|                  | `C`        | S-expression with `FlexUInt` length prefix           |
-|                  | `D`        | Struct with `FlexUInt` length prefix                 |
-|                  | `E`        | Blob with `FlexUInt` length prefix                   |
-|                  | `F`        | Clob with `FlexUInt` length prefix                   |
+| High nibble      | Low nibble | Meaning                                                                         |
+|------------------|------------|---------------------------------------------------------------------------------|
+| `0x0_` to `0x3_` | `0`-`F`    | E-expression with 6-bit address                                                 |
+| `0x4_`           | `0`-`F`    | E-expression with 12-bit address                                                |
+| `0x5_`           | `0`-`F`    | E-expression with 20-bit address                                                |
+| `0x6_`           | `0`-`8`    | Integers from 0 to 8 bytes wide                                                 |
+|                  | `9`        | _Reserved_                                                                      |
+|                  | `A`-`D`    | Floats                                                                          |
+|                  | `E`-`F`    | Booleans                                                                        |
+| `0x7_`           | `0`-`F`    | Decimals                                                                        |
+| `0x8_`           | `0`-`C`    | Short-form timestamps                                                           |
+|                  | `D`-`F`    | _Reserved_                                                                      |
+| `0x9_`           | `0`-`F`    | Strings                                                                         |
+| `0xA_`           | `0`-`F`    | Symbols with inline text                                                        |
+| `0xB_`           | `0`-`F`    | Lists                                                                           |
+| `0xC_`           | `0`-`F`    | S-expressions                                                                   |
+| `0xD_`           | `0`        | Empty struct                                                                    |
+|                  | `1`        | _Reserved_                                                                      |
+|                  | `2`-`F`    | Structs                                                                         |
+| `0xE_`           | `0`        | Ion version marker                                                              |
+|                  | `1`-`3`    | Symbols with symbol address                                                     |
+|                  | `4`-`6`    | Annotations with symbol address                                                 |
+|                  | `7`-`9`    | Annotations with `FlexSym` text                                                 |
+|                  | `A`        | `null.null`                                                                     |
+|                  | `B`        | Typed nulls                                                                     |
+|                  | `C`-`D`    | NOP                                                                             |
+|                  | `E`        | System symbol                                                                   |
+|                  | `F`        | System macro invocation                                                         |
+| `0xF_`           | `0`        | Delimited container end                                                         |
+|                  | `1`        | Delimited list start                                                            |
+|                  | `2`        | Delimited S-expression start                                                    |
+|                  | `3`        | Delimited struct start                                                          |
+|                  | `4`        | E-expression with `FlexUInt` macro address                                      |
+|                  | `5`        | E-expression with `FlexUInt` macro address followed by `FlexUInt` length prefix |
+|                  | `6`        | Integer with `FlexUInt` length prefix                                           |
+|                  | `7`        | Decimal with `FlexUInt` length prefix                                           |
+|                  | `8`        | Timestamp with `FlexUInt` length prefix                                         |
+|                  | `9`        | String with `FlexUInt` length prefix                                            |
+|                  | `A`        | Symbol with `FlexUInt` length prefix and inline text                            |
+|                  | `B`        | List with `FlexUInt` length prefix                                              |
+|                  | `C`        | S-expression with `FlexUInt` length prefix                                      |
+|                  | `D`        | Struct with `FlexUInt` length prefix                                            |
+|                  | `E`        | Blob with `FlexUInt` length prefix                                              |
+|                  | `F`        | Clob with `FlexUInt` length prefix                                              |

--- a/_books/ion-1-1/src/binary/primitives.md
+++ b/_books/ion-1-1/src/binary/primitives.md
@@ -1,5 +1,5 @@
 # Primitives
-This section describes Ion 1.1's binary _encoding primitives_--reusable building blocks
+This section describes Ion 1.1's binary _encoding primitives_—reusable building blocks
 that can be combined to represent more complex constructs.
 
 | Name                                    | Type     | Width                     |

--- a/_books/ion-1-1/src/binary/primitives/flex_int.md
+++ b/_books/ion-1-1/src/binary/primitives/flex_int.md
@@ -7,8 +7,9 @@ how many bytes were used to encode the integer. They differ in the _interpretati
 `FlexUInt`'s bits are unsigned, a `FlexInt`'s bits are encoded using
 [two's complement notation](https://en.wikipedia.org/wiki/Two%27s_complement).
 
-TIP: An implementation could choose to read a `FlexInt` by instead reading a `FlexUInt` and then reinterpreting its bits
-as two's complement.
+> [!Tip]
+> An implementation could choose to read a `FlexInt` by instead reading a `FlexUInt` and then reinterpreting its bits
+> as two's complement.
 
 #### `FlexInt` encoding of `14`
 ```

--- a/_books/ion-1-1/src/binary/primitives/flex_sym.md
+++ b/_books/ion-1-1/src/binary/primitives/flex_sym.md
@@ -3,7 +3,7 @@
 A variable-length symbol token whose UTF-8 bytes can be inline, found in the symbol table, or derived from a macro
 expansion.
 
-A `FlexSym` begins with a [`FlexInt`](#flexint); once this integer has been read, we can evaluate it to determine how to proceed. If the FlexInt is:
+A `FlexSym` begins with a [`FlexInt`](flex_int.md); once this integer has been read, we can evaluate it to determine how to proceed. If the FlexInt is:
 
 * **greater than zero**, it represents a symbol ID. The symbol’s associated text can be found in the local symbol table.
 No more bytes follow.
@@ -41,7 +41,7 @@ The `FlexSym` parser is not responsible for evaluating a `FlexSymOpCode`, only r
 Example usages of the `FlexSymOpCode` include:
 * Representing SID `$0`
 * Representing system symbols
-  * Note that the empty symbol (i.e. the symbol `''`) is now a system symbol and can be referenced this way.
+  * Note that the empty symbol (i.e. the symbol `''`) is a system symbol and can be referenced this way.
 * When used to encode a struct field name, the opcode can invoke a macro that will evaluate 
   to a struct whose key/value pairs are spliced into the parent [struct](../values/struct.md).
 * In a [delimited struct](../values/struct.md#delimited-encoding), terminating the sequence of `(field name, value)` pairs with `0xF0`.
@@ -52,7 +52,6 @@ Example usages of the `FlexSymOpCode` include:
 | `0x00` - `0x5F` | E-Expression                                  | May be used when the `FlexSym` occurs in the field name position of any struct                                                                                                                                               |
 |     `0x60`      | Symbol with unknown text (also known as `$0`) |                                                                                                                                                                                                                              |
 | `0x61` - `0xDF` | System SID (with `0x60` bias)                 | While the range of `0x61` - `0xDF` is reserved for system symbols, not all of these bytes correspond to a system symbol. See [system symbols](../../modules/system_module.md#system-symbols) for the list of system symbols. |
-|     `0xEE`      | System symbol                                 |                                                                                                                                                                                                                              |
 |     `0xEF`      | E-Expression invoking a system macro          | May be used when the `FlexSym` occurs in the field name position of any struct                                                                                                                                               |
 |     `0xF0`      | Delimited container end marker                | May only be when the `FlexSym` occurs in the field name position of a delimited struct                                                                                                                                       |
 |     `0xF5`      | Length-prefixed macro invocation              | May be used when the `FlexSym` occurs in the field name position of any struct                                                                                                                                               |

--- a/_books/ion-1-1/src/binary/values/decimal.md
+++ b/_books/ion-1-1/src/binary/values/decimal.md
@@ -3,7 +3,7 @@
 If an opcode has a high nibble of `0x7_`, it represents a decimal. Low nibble values indicate
 the number of trailing bytes used to encode the decimal.
 
-The body of the decimal is encoded as a [`FlexInt`](#flexint) representing its exponent, followed by a `FixedInt`
+The body of the decimal is encoded as a [`FlexInt`](../primitives/flex_int.md) representing its exponent, followed by a `FixedInt`
 representing its coefficient. The width of the coefficient is the total length of the decimal encoding minus the length
 of the exponent. It is possible for the coefficient to have a width of zero, indicating a coefficient of `0`. When
 the coefficient is present but has a value of `0`, the coefficient is `-0`.

--- a/_books/ion-1-1/src/binary/values/int.md
+++ b/_books/ion-1-1/src/binary/values/int.md
@@ -1,12 +1,11 @@
 ## Integers
 
-Opcodes in the range `0x60` to `0x68` represent an integer. The opcode is followed by a [`FixedInt`](#fixedint) that
+Opcodes in the range `0x60` to `0x68` represent an integer. The opcode is followed by a [`FixedInt`](../primitives/fixed_int.md) that
 represents the integer value. The low nibble of the opcode (`0x_0` to `0x_8`) indicates the size of the `FixedInt`.
 Opcode `0x60` represents integer `0`; no more bytes follow.
 
 Integers that require more than 8 bytes are encoded using the variable-length integer opcode `0xF6`,
-followed by a
-<<flexuint, FlexUInt>> indicating how many bytes of representation data follow.
+followed by a [`FlexUInt`](../primitives/flex_uint.md) indicating how many bytes of representation data follow.
 
 `0xEB 0x01` represents `null.int`.
 

--- a/_books/ion-1-1/src/binary/values/string.md
+++ b/_books/ion-1-1/src/binary/values/string.md
@@ -3,7 +3,7 @@
 If the high nibble of the opcode is `0x9_`, it represents a string. The low nibble of the opcode
 indicates how many UTF-8 bytes follow. Opcode `0x90` represents a string with empty text (`""`).
 
-Strings longer than 15 bytes can be encoded with the `F9` opcode, which takes a [`FlexUInt`](#flexuint)-encoded length
+Strings longer than 15 bytes can be encoded with the `F9` opcode, which takes a [`FlexUInt`](../primitives/flex_uint.md)-encoded length
 after the opcode.
 
 `0xEB x05` represents `null.string`.

--- a/_books/ion-1-1/src/binary/values/struct.md
+++ b/_books/ion-1-1/src/binary/values/struct.md
@@ -13,7 +13,7 @@ If the struct's encoded byte-length is too large to be encoded in a nibble, writ
 to write a variable-length struct. The `0xFD` opcode is followed by a [`FlexUInt`](../primitives/flex_uint.md)
 that indicates the byte length.
 
-Each field in the struct is encoded as a [`FlexUInt`](#flexuint) representing the address of the field name's
+Each field in the struct is encoded as a [`FlexUInt`](../primitives/flex_uint.md) representing the address of the field name's
 text in the symbol table, followed by an opcode-prefixed value.
 
 `0xEB 0x0B` represents `null.struct`.
@@ -113,14 +113,11 @@ D5 01 01 E1 00 61 01
 ### Delimited encoding
 
 Opcode `0xF3` indicates the beginning of a delimited struct. Unlike [length-prefixed structs](#length-prefixed-encoding),
-delimited structs _always_ encode their field names as [`FlexSym`](#flexsym)s.
+delimited structs _always_ encode their field names as [`FlexSym`](../primitives/flex_sym.md)s.
 
 Unlike lists and S-expressions, structs cannot use opcode `0xF0` by itself to indicate the end of the delimited
 container. This is because `0xF0` is a valid `FlexSym` (a symbol with 16 bytes of inline text). To close the delimited
 struct, the writer emits a `0x01` byte (a `FlexSym` escape) followed by the opcode `0xF0`.
-
-> [!NOTE]
-> It is much more compact to write `0xD0`-- the [empty length-prefixed struct](#length-prefixed-encoding-of-an-empty-struct-).
 
 #### Delimited encoding of the empty struct (`{}`)
 ```
@@ -130,6 +127,9 @@ struct, the writer emits a `0x01` byte (a `FlexSym` escape) followed by the opco
 │  │  │    recently opened delimited container
 F3 01 F0
 ```
+
+> [!NOTE]
+> It is much more compact to write `0xD0`—the [empty length-prefixed struct](#length-prefixed-encoding-of-an-empty-struct-).
 
 #### Delimited encoding of `{"foo": 1, $11: 2}`
 ```

--- a/_books/ion-1-1/src/binary/values/symbol.md
+++ b/_books/ion-1-1/src/binary/values/symbol.md
@@ -48,10 +48,10 @@ EB 06
 Symbol values whose text can be found in the local symbol table are encoded using opcodes `0xE1` through `0xE3`:
 
 * `0xE1` represents a symbol whose address in the symbol table (aka its symbol ID) is a 1-byte
-[`FixedUInt`](#fixeduint) that follows the opcode.
-* `0xE2` represents a symbol whose address in the symbol table is a 2-byte [`FixedUInt`](#fixeduint) that follows
+[`FixedUInt`](../primitives/fixed_uint.md) that follows the opcode.
+* `0xE2` represents a symbol whose address in the symbol table is a 2-byte [`FixedUInt`](../primitives/fixed_uint.md) that follows
 the opcode.
-* `0xE3` represents a symbol whose address in the symbol table is a [`FlexUInt`](#flexuint) that follows the opcode.
+* `0xE3` represents a symbol whose address in the symbol table is a [`FlexUInt`](../primitives/flex_uint.md) that follows the opcode.
 
 Writers MUST encode a symbol address in the smallest number of bytes possible. For each opcode above, the symbol
 address that is decoded is biased by the number of addresses that can be encoded in fewer bytes.

--- a/_books/ion-1-1/src/binary/values/timestamp.md
+++ b/_books/ion-1-1/src/binary/values/timestamp.md
@@ -29,13 +29,13 @@ the variable-length [long form timestamp](#long-form-timestamps) encoding.
 
 Timestamps may be encoded using the short form if they meet all of the following conditions:
 
-The year is between 1970 and 2097.:: The year subfield is encoded as the number of years since 1970. 7 bits are
+- **The year is between 1970 and 2097.** The year subfield is encoded as the number of years since 1970. 7 bits are
 dedicated to representing the biased year, allowing timestamps through the year 2097 to be encoded in this form.
-The local offset is either UTC, unknown, or falls between `-14:00` to `+14:00` and is divisible by 15 minutes.
+- **The local offset is either UTC, unknown, or falls between `-14:00` to `+14:00` and is divisible by 15 minutes.**
 7 bits are dedicated to representing the local offset as the number of quarter hours from -56 (that is: offset `-14:00`).
 The value `0b1111111` indicates an unknown offset. At the time of this writing (2024-08T),
 [all real-world offsets fall between `-12:00` and `+14:00` and are multiples of 15 minutes](https://en.wikipedia.org/wiki/List_of_UTC_offsets).
-The fractional seconds are a common precision. The timestamp's fractional second precision (if present) is
+- **The fractional seconds are a common precision.** The timestamp's fractional second precision (if present) is
 either 3 digits (milliseconds), 6 digits (microseconds), or 9 digits (nanoseconds).
 
 #### Opcodes by precision and offset
@@ -45,21 +45,21 @@ Each opcode with a high nibble of `0x8_` indicates a different precision and off
 | Opcode | Precision        | Serialized size in bytes[^short_form_size_in_bytes] | Offset encoding                                                |
 |--------|------------------|:---------------------------------------------------:|----------------------------------------------------------------|
 | `0x80` | Year             |                          1                          | Implicitly _Unknown offset_                                    |
-| `0x81` | Month            |                          2                          |                                                                |
-| `0x82` | Day              |                          2                          |                                                                |
+| `0x81` | Month            |                          2                          | Implicitly _Unknown offset_                                    |
+| `0x82` | Day              |                          2                          | Implicitly _Unknown offset_                                    |
 | `0x83` | Hour and minutes |                          4                          | 1 bit to indicate _UTC_ or _Unknown Offset_                    |
-| `0x84` | Seconds          |                          5                          |                                                                |
-| `0x85` | Milliseconds     |                          6                          |                                                                |
-| `0x86` | Microseconds     |                          7                          |                                                                |
-| `0x87` | Nanoseconds      |                          8                          |                                                                |
+| `0x84` | Seconds          |                          5                          | 1 bit to indicate _UTC_ or _Unknown Offset_                    |
+| `0x85` | Milliseconds     |                          6                          | 1 bit to indicate _UTC_ or _Unknown Offset_                    |
+| `0x86` | Microseconds     |                          7                          | 1 bit to indicate _UTC_ or _Unknown Offset_                    |
+| `0x87` | Nanoseconds      |                          8                          | 1 bit to indicate _UTC_ or _Unknown Offset_                    |
 | `0x88` | Hour and minutes |                          5                          | 7 bits to represent a known offset.[^short_form_hours_minutes] |
-| `0x89` | Seconds          |                          5                          |                                                                |
-| `0x8A` | Milliseconds     |                          7                          |                                                                |
-| `0x8B` | Microseconds     |                          8                          |                                                                |
-| `0x8C` | Nanoseconds      |                          9                          |                                                                |
-| `0x8D` | _Reserved_       |                         --                          |                                                                |
-| `0x8E` | _Reserved_       |                         --                          |                                                                |
-| `0x8F` | _Reserved_       |                         --                          |                                                                |
+| `0x89` | Seconds          |                          5                          | 7 bits to represent a known offset.                            |
+| `0x8A` | Milliseconds     |                          7                          | 7 bits to represent a known offset.                            |
+| `0x8B` | Microseconds     |                          8                          | 7 bits to represent a known offset.                            |
+| `0x8C` | Nanoseconds      |                          9                          | 7 bits to represent a known offset.                            |
+| `0x8D` | _Reserved_       |                         --                          |  --                                                            |
+| `0x8E` | _Reserved_       |                         --                          |  --                                                            |
+| `0x8F` | _Reserved_       |                         --                          |  --                                                            |
 
 [^short_form_size_in_bytes]: Serialized size in bytes does not include the opcode.
 
@@ -111,7 +111,7 @@ read from right to left (also least significant to most significant.)
 
 > [!NOTE]
 > While this encoding may complicate human reading, it guarantees that the timestamp's subfields (`year`, `month`,
-> etc.) occupy the same bit contiguous indexes regardless of how many bytes there are overall. (The last subfield,
+> etc.) occupy the same contiguous bit indexes regardless of how many bytes there are overall. (The last subfield,
 > `fractional_seconds`, always begins at the same bit index when present, but can vary in length according to the
 > precision.) This arrangement allows processors to read the Little-Endian bytes into an integer and then mask the
 > appropriate bit ranges to access the subfields.


### PR DESCRIPTION
### Issue #, if available:

Fixes #374 

### Description of changes:
* Fixed a bunch of links. All of them in this section seem to work now (except for the ones I missed).
* Removed 0xEE from the FlexSym opcodes, as we now have a range of opcodes available for the system SIDs.
* Other minor cleanups.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
