### PR TITLE
Use a locked cargo install in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,13 +33,15 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: mdbook --no-default-features --features search --vers "^0.4"
+          # --locked is necessary until https://github.com/mattico/elasticlunr-rs/pull/57
+          # But it probably doesn't hurt in any case
+          args: mdbook --no-default-features --features search --vers "^0.4" --locked
 
       - name: Install MdBook-alerts
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: mdbook-alerts
+          args: mdbook-alerts --locked
 
       - name: Build
         run: |

--- a/_plugins/mdbooks.rb
+++ b/_plugins/mdbooks.rb
@@ -5,7 +5,11 @@ module IonDocs
     safe true
     def generate(site)
       # If we have more books, either loop through them, or add a new line for each
-      system( "mdbook build ./_books/ion-1-1 -d ./../../_site/books/ion-1-1" )
+      system(
+        %w[mdbook build
+          ./_books/ion-1-1
+          -d ./../../_site/books/ion-1-1
+        ]) or fail "mdbook process exited with status $?"
     end
   end
 end


### PR DESCRIPTION
### Description of changes:

This should fix the failure in deploy.yml that we have seen most recently:
```plain
2025-03-17 19:21:11 [INFO] (mdbook::book): Running the html backend

thread 'main' panicked at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/elasticlunr-rs-3.0.3/src/lang/en.rs:518:47:
index out of bounds: the len is 3 but the index is 18446744073709551615
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
    Liquid Warning: Liquid syntax error (line 75): [:end_of_string] is not a valid expression in "{{}}" in index.md
                    done in 1.444 seconds.
 Auto-regeneration: disabled. Use --watch to enable.
```

For more information, see mattico/elasticlunr-rs#57, the mitigation comes from a [recommendation](https://github.com/rust-lang/mdBook/issues/971#issuecomment-2727816379) from the `mdBook` maintainers.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
