### PR TITLE
Have to destructure array arg to system

### DIFF
--- a/_plugins/mdbooks.rb
+++ b/_plugins/mdbooks.rb
@@ -6,7 +6,7 @@ module IonDocs
     def generate(site)
       # If we have more books, either loop through them, or add a new line for each
       system(
-        %w[mdbook build
+        *%w[mdbook build
           ./_books/ion-1-1
           -d ./../../_site/books/ion-1-1
         ]) or fail "mdbook process exited with status $?"


### PR DESCRIPTION
### Description of changes:

The previous PR #388 had an error- I forgot that I needed to [splat](https://www.honeybadger.io/blog/ruby-splat-array-manipulation-destructuring/) the [bareword array](https://stackoverflow.com/questions/1274675/what-does-warray-mean) to destructure it into arguments. I most recently worked with a different process invocation interface which took an array, so I misremembered that the Ruby `system` call could as well. 

Testing:

```
❯ pry
[1] pry(main)> system(%w[echo foo bar buzz])
ArgumentError: wrong first argument
from (pry):1:in `system'
[2] pry(main)> system(*%w[echo foo bar buzz])
foo bar buzz
=> true
```
----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
