### PR TITLE
Update (formal spec) base container image to Ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Inspired by https://github.com/simdjson/simdjson/blob/master/Dockerfile
 
-FROM ubuntu:23.04
+# https://ubuntu.com/about/release-cycle
+# Support for 24.04 (Noble Numbat) ends in 2029-04T
+FROM ubuntu:24.04
 
 ARG USER_ID
 ARG GROUP_ID


### PR DESCRIPTION
Odd-numbered Ubuntu releases only have 9mo support. https://ubuntu.com/about/release-cycle

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
