### PR TITLE
Remove wording around macro name omission

### DIFF
--- a/_books/ion-1-1/src/macros/defining_macros.md
+++ b/_books/ion-1-1/src/macros/defining_macros.md
@@ -32,7 +32,7 @@ A macro is defined using a `macro` clause within a [module](../modules.md)'s [`m
 Syntactically, macro names are [identifiers](../text/symbol-tokens.md). Each macro name in a macro table must be unique.
 
 In some circumstances, it may not make sense to name a macro. (For example, when the macro is generated automatically.)
-In such cases, authors may use the symbol `null` to indicate that the macro does not have a name.
+In such cases, authors must use `null` to indicate that the macro does not have a name.
 Anonymous macros can only be referenced by their address in the macro table.
 
 ## Macro parameters

--- a/_books/ion-1-1/src/macros/defining_macros.md
+++ b/_books/ion-1-1/src/macros/defining_macros.md
@@ -7,11 +7,11 @@ A macro is defined using a `macro` clause within a [module](../modules.md)'s [`m
 (macro name signature template)
 ```
 
-| Argument                                        | Description                                                                                               |
-|-------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
-| [`name`](#macro-names)                          | A unique name assigned to the macro. When constructing an anonymous macro, this argument is omitted.      |
-| [`signature`](#macro-signatures)                | An s-expression enumerating the parameters this macro accepts.                                            |
-| [`template`](#template-definition-language-tdl) | A template definition language (TDL) expression that can be evaluated to produce zero or more Ion values. |
+| Argument                                        | Description                                                                                                                    |
+|-------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| [`name`](#macro-names)                          | A unique name assigned to the macro. When constructing an anonymous macro `null` is used in the place of a unique name.        |
+| [`signature`](#macro-signatures)                | An s-expression enumerating the parameters this macro accepts.                                                                 |
+| [`template`](#template-definition-language-tdl) | A template definition language (TDL) expression that can be evaluated to produce zero or more Ion values.                      |
 
 ### Example macro clause
 ```ion
@@ -32,7 +32,7 @@ A macro is defined using a `macro` clause within a [module](../modules.md)'s [`m
 Syntactically, macro names are [identifiers](../text/symbol-tokens.md). Each macro name in a macro table must be unique.
 
 In some circumstances, it may not make sense to name a macro. (For example, when the macro is generated automatically.)
-In such cases, authors may omit the macro name to indicate that the macro does not have a name.
+In such cases, authors may use the symbol `null` to indicate that the macro does not have a name.
 Anonymous macros can only be referenced by their address in the macro table.
 
 ## Macro parameters

--- a/_books/ion-1-1/src/modules/defining_modules.md
+++ b/_books/ion-1-1/src/modules/defining_modules.md
@@ -119,7 +119,7 @@ Most commonly, a macro table entry is a definition of a new macro expansion func
 ```
 (See the [_Defining macros_](../macros/defining_macros.md) for details.)
 
-When no name is given, this defines an anonymous macro that can be referenced by its numeric
+When the value `null` is given for the macro name, this defines an anonymous macro that can be referenced by its numeric
 address (that is, its index in the enclosing macro table).
 Inside the defining module, that uses a local reference like `12`.
 


### PR DESCRIPTION
### Issue #, if available: n/a

### Description of changes:
As discussed earlier this week, the current implementations do not allow a macro name to be omitted, and instead rely on `null` to be used as the macro name for anonymous macros. Since macros are intended to be used by machinery, auto-generating and consuming macros, the inclusion of `null` is not seen as a readability concern, and the savings of removing it does not outweigh the parsing complexity.

This PR removes the wording around macro names being omitted, and replaces it with using the value `null` to indicate an anonymous macro.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
