### PR TITLE
Update discord link with an invite that doesn't expire

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,4 +22,4 @@ keep_files:
 
 # Discord server invite link
 discord:
-  invite_url: "https://discord.gg/2cbJNjGU"
+  invite_url: "https://discord.gg/mG2ST2qgbJ"


### PR DESCRIPTION
### Issue #, if available:

N/A

### Description of changes:

I noticed that the discord link that was used will expire tomorrow. I've created a new link that has no expiration date.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
