### PR TITLE
Updates the Ion 1.1 text encoding pages and adds a page to enumerate the available tagless encodings.

### DIFF
--- a/_books/ion-1-1/src/SUMMARY.md
+++ b/_books/ion-1-1/src/SUMMARY.md
@@ -5,6 +5,7 @@
 - [Macros](macros.md)
     - [Macros by example](macros/macros_by_example.md)
     - [Defining macros](macros/defining_macros.md)
+    - [Tagless encodings](macros/tagless_encodings.md)
 - [Modules](modules.md)
     - [Defining modules](modules/defining_modules.md)
     - [Directives](modules/directives.md)

--- a/_books/ion-1-1/src/macros/tagless_encodings.md
+++ b/_books/ion-1-1/src/macros/tagless_encodings.md
@@ -1,0 +1,50 @@
+# Tagless Encodings
+
+Tagless encodings may be specified by type markers in template placeholders and in tagless-element sequences. In binary,
+this allows the opcode to be elided from the encoding of values that fill tagless slots.
+
+
+Consider the following data:
+```ion
+[
+  { sum: 123, sample_count: 12 },
+  { sum: 54, sample_count: 8 },
+  { sum: 125, sample_count: 15 },
+  { sum: 314, sample_count: 30 },
+]
+```
+With a macro such as `(metric {sum: (:?\int\), sample_count: (:?\int\), unit: ms})`, it can be encoded as
+```ion
+[\:metric\
+  (123 12),
+  (54 8),
+  (125 15),
+  (314 30),
+]
+```
+
+The available tagless encodings are enumerated in the following table.
+
+| Ion Type    | Encoding Name   | Size in bytes | Binary Encoding Tag | Encoding                                                                        |
+|-------------|:----------------|:-------------:|:-------------------:|:--------------------------------------------------------------------------------|
+| `int`       | `int`           |   variable    |       `0x60`        | [`FlexInt`][flexint]                                                            |
+|             | `int8`          |       1       |       `0x61`        | [`FixedInt`][fixedint]                                                          |
+|             | `int16`         |       2       |       `0x62`        | [`FixedInt`][fixedint]                                                          |
+|             | `int32`         |       4       |       `0x64`        | [`FixedInt`][fixedint]                                                          |
+|             | `int64`         |       8       |       `0x68`        | [`FixedInt`][fixedint]                                                          |
+|             | `uint`          |   variable    |       `0xE0`        | [`FlexUInt`][flexuint]                                                          |
+|             | `uint8`         |       1       |       `0xE1`        | [`FixedUInt`][fixeduint]                                                        |
+|             | `uint16`        |       2       |       `0xE2`        | [`FixedUInt`][fixeduint]                                                        |
+|             | `uint32`        |       4       |       `0xE4`        | [`FixedUInt`][fixeduint]                                                        |
+|             | `uint64`        |       8       |       `0xE8`        | [`FixedUInt`][fixeduint]                                                        |
+| `float`     | `float16`       |       2       |       `0x6B`        | [Little-endian IEEE-754 half-precision float][f16]                              |
+|             | `float32`       |       4       |       `0x6C`        | [Little-endian IEEE-754 single-precision float][f32]                            |
+|             | `float64`       |       8       |       `0x6D`        | [Little-endian IEEE-754 double-precision float][f64]                            |
+| `decimal`   | `small_decimal` | variable (2+) |       `0x70`        | Tuple of (`int`,`int8`) representing the coefficient and exponent respectively. |
+| `timestamp` | `timestamp_day` |       2       |       `0x82`        | [Day precision timestamp][t1]                                                   |
+|             | `timestamp_min` |       4       |       `0x83`        | [Minute precision timestamp][t2]                                                |
+|             | `timestamp_s`   |       5       |       `0x84`        | [Second precision timestamp][t3]                                                |
+|             | `timestamp_ms`  |       6       |       `0x85`        | [Millisecond precision timestamp][t4]                                           |
+|             | `timestamp_us`  |       7       |       `0x86`        | [Microsecond precision timestamp][t5]                                           |
+|             | `timestamp_ns`  |       8       |       `0x87`        | [Nanosecond precision timestamp][t6]                                            |
+| `symbol`    | `symbol`        |   variable    |       `0xEE`        | [`FlexSym`][flexsym]                                                            |

--- a/_books/ion-1-1/src/text/e_expressions.md
+++ b/_books/ion-1-1/src/text/e_expressions.md
@@ -24,78 +24,64 @@ E-expressions may be annotated.
 foo::(:pi)         // E-expression annotated with 'foo'
 ```
 
-E-expressions may also appear in structs in place of an entire name-value pair.
+E-expressions may in structs in value position, but not field name position.
 ```ion
 {
   foo: 1,
-  (:bar 2), // Expands to a struct that is spliced into this struct
+  bar: (:bar 2), // Expands to a value associated with the field name 'bar'
+  (:bar 3)       // ERROR: e-expressions may not occur in field name position
 }
 ```
 
-### Expression Groups
-
-To pass multiple arguments to a single macro parameter, the arguments to the parameter must be delimited by an _Expression Group_.
-
-Inside an E-expression, an expression group starts with `(::`.
-The remainder of the expression group uses the same syntax as an [S-expression](values.md#s-expressions).
-Expression groups are not values, so they may not be annotated.
-Expression groups may not contain another expression group.
-
+When an e-expression represents a macro invocation that contains trailing optional parameters,
+any or all of the trailing optionals may be elided from the e-expression.
 
 ```ion
-(:make_string (:: "a" "b" "c" "d"))
-//                └──────┬──────┘
-//                       └── 4 argument expressions passed to `parts`
-
-(:make_string (:: "a" (:: "b" "c") "d") )    // ERROR: Expression groups may only occur directly in an E-expression
+($ion set_macros (foo {bar: (:?), baz: (:? 123)})) // Both parameters are optional
+(:foo abc)     // ⇒ {bar: abc, baz: 123}
+(:foo abc (:)) // Equivalent to the previous line. Second optional explicitly suppressed using `(:)`
+(:foo)         // ⇒ {baz: 123}
+(:foo (:) (:)) // Equivalent to the previous line. Both optionals explicitly suppressed using `(:)`
 ```
 
+### Template Placeholders
 
-### Rest Arguments
+Template placeholders are special E-Expressions that help define template macros.
 
-Rest arguments are a special-case of expression groups that is only applicable to Ion 1.1 text. 
-When the final parameter in the macro signature is `zero-or-more` or `one-or-more`, "all the rest" of the argument expressions will be passed to that parameter.
-Rest arguments are an implicit expression group, and may not include any explicit expression groups. 
+Examples:
 
-```ion
-(:make_string)
-//           └── 0 argument expressions passed to `parts`
-(:make_string "a")
-//            └┬┘
-//             └── 1 argument expression passed to `parts`
-(:make_string "a" "b" "c" "d")
-//            └──────┬──────┘
-//                   └── 4 argument expressions passed to `parts`
+* Tagged value, optional, no default value: `(:?)`
+* Tagged value, optional, with default value: `(:? "foo")`
+* Tagless value (with type marker), required, default value not allowed: `(:?\int8\)`
 
-(:make_string (:: "a" "b" "c" "d"))
-//                └──────┬──────┘
-//                       └── Also 4 argument expressions passed to `parts`
+### Type Markers
 
-(:make_string (:: "a") "b" "c" "d")   // ERROR: Too many arguments
-(:make_string "a" (:: "b") "c" "d")   // ERROR: Too many arguments
-```
+Type markers are used in tagless e-expression placeholders and
+[tagless-element sequences](values.md#tagless-element-sequences).
+The text syntax for type markers consists of a [tagless type identifier](../macros/tagless_encodings.md)
+surrounded by `\`.
 
+Examples:
+ * named macro-shape: `\:foo\`, `\:foo_module::bar_macro\`
+ * macro-shape by id: `\:12\`, `\:493\`
+ * tagless scalar type by name: `\int\`, `\uint8\`, `\string\`, `\symbol\`, `\timestamp\`
+ * tagless scalar type by opcode: `\0x61\`, `\0xEE\`
+
+Macros that accept 0 arguments are not eligible to be used in a type marker.
 
 ### Macro-shaped parameters
 
 Macro-shaped parameters are tagless parameters whose encoding type is the arguments for another macro.
-(See [Macros by Example](../macros/macros_by_example.md#macro-shapes).)
 In Ion text, each set of arguments for a macro-shape parameter must be enclosed between `(` and `)`.
 The only difference between this and an E-expression is the lack of the ':' and macro reference at the start of the E-expression.
 The arguments for a macro-shape use the same syntax as the arguments to any other E-expression.
 
 ```ion
-// Given the following macro signatures:
-//   (macro point (x y) ...)
-//   (macro line_segment (point::a point::b) ...)
-//   (macro polygon (point::points*) ...)
+// Given the following macros:
+//   (point {x: (:?), y: (:?)})
+//   (line_segment {a: (?:\point\), b: (?:\point\)})
 
 (:line_segment (0 1) (4 8) )
 //             └─┬─┘ └─┬─┘
 //               │     └── Implicit invocation of (:point ...) for parameter b
 //               └── Implicit invocation of (:point ...) for parameter a
-
-(:polygon (:: (1 1) (1 2) (2 4) (2 5) ))
-//            └──────────┬──────────┘
-//                       └── 4 macro-shaped arguments passed to `points`
-```

--- a/_books/ion-1-1/src/text/values.md
+++ b/_books/ion-1-1/src/text/values.md
@@ -14,9 +14,8 @@ degrees::'celsius'::100                  // You can have multiple annotaions on 
 jpeg :: {{ ... }}                        // Indicates the blob contains jpeg data
 bool :: null.int                         // A very misleading annotation on the integer null
 '' :: 1                                  // An empty annotation
-null.symbol :: 1                         // ERROR: type annotation cannot be null 
-foo::(:make_string "a" "b")              // ERROR: e-expressions may not be annotated
-(:make_string foo::(:: "a" "b"))         // ERROR: expression groups may not be annotated
+foo::(:bar "a" "b")                      // E-expressions may be annotated
+null.symbol :: 1                         // ERROR: type annotation cannot be null
 ```
 
 ## Nulls
@@ -463,6 +462,26 @@ escaped with single quotes:
 ```ion
 (a/* word */b)       // An S-expression with two symbols and a comment
 (a '/*' word '*/' b) // An S-expression with five symbols
+```
+
+# Tagless-element Sequences
+
+Tagless-element sequences allow for sequences (lists or s-expressions) to be encoded in binary without repetitively
+declaring the same opcode.
+
+In text, tagless-element sequences are differentiated from regular sequences by adding a [type marker](e_expressions.md#type-markers)
+immediately after the opening delimiter.
+
+When the type is a macro-shape, the arguments for each instance of the macro invocation are enclosed in `(` and `)`.
+
+Macros that accept 0 arguments may not be used as a macro-shape type for a tagless-element sequence.
+
+Examples:
+```ion
+[:\int8\ 1, 2, 3, 4]
+[\:point\ (1 3), (1 4), (2 4)]
+(\x60\ 1 -2 3 -99999999999999999999999)
+(\:foo\)
 ```
 
 ## Structs

--- a/_books/ion-1-1/src/text/values.md
+++ b/_books/ion-1-1/src/text/values.md
@@ -481,7 +481,8 @@ Examples:
 [:\int8\ 1, 2, 3, 4]
 [\:point\ (1 3), (1 4), (2 4)]
 (\x60\ 1 -2 3 -99999999999999999999999)
-(\:foo\)
+(\:foo\)        // An empty, macro-shaped s-expression
+[\int8\ 1, 2, 3, foo::4]  // ERROR: tagless elements cannot have annotations
 ```
 
 ## Structs


### PR DESCRIPTION
### Issue #:
#397 

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
