### PR TITLE
Updates the Ion 1.1 text grammar.

### DIFF
--- a/_books/ion-1-1/src/grammar.md
+++ b/_books/ion-1-1/src/grammar.md
@@ -4,42 +4,50 @@ This chapter presents Ion 1.1's _domain grammar_, by which we mean the grammar o
 of values that drive Ion's encoding features.
 
 We use a BNF-like notation for describing various syntactic parts of a document, including Ion data structures. 
-In such cases, the BNF should be interpreted loosely to accommodate Ion-isms like commas and unconstrained ordering of struct fields.
+In such cases, the BNF should be interpreted loosely to accommodate Ion-isms like commas, whitespace, and unconstrained ordering of struct fields.
+
+For brevity, the following components are not explicitly defined in this grammar:
+* `value` - any Ion value literal
+* `unannotated-identifier-symbol` - an unannotated "identifier symbol" (as defined in the specification)
+* `unannotated-uint` - an unannotated integer greater than or equal to zero
 
 ### Documents
 ```bnf
-document           ::= ivm? segment*
+document           ::= ivm segment*
 
-ivm                ::= '$ion_1_0' | '$ion_1_1'
+ivm                ::= '$ion_1_1'
 
-segment            ::= value* directive?
+any-value-encoding ::= value | macro-invocation | tagless-element-list | tagless-element-sexp
 
-directive          ::= ivm 
-                     | encoding-directive 
-                     | symtab-directive 
+segment            ::= any-value-encoding* directive?
 
-symtab-directive   ::=  local-symbol-table     ; As per the Ion 1.0 specification¹
-
-encoding-directive ::= '$ion::(encoding ' module-name* ')'
+directive          ::= ivm | encoding-directive
 ```
 
-&nbsp;&nbsp;&nbsp;&nbsp;¹[Symbols – Local Symbol Tables](https://amazon-ion.github.io/ion-docs/docs/symbols.html#local-symbol-tables).
+### Directives
+```bnf
+encoding-directive    ::= '(:$ion ' any-directive-content ')'
+
+any-directive-content ::= set-symbols-content | add-symbols-content | set-macros-content | add-macros-content
+                        | use-content | module-content | import-content | encoding-content
+
+set-symbols-content   ::= 'set_symbols' symbol-text*
+add-symbols-content   ::= 'add_symbols' symbol-text*
+set-macros-content    ::= 'set_macros' macro-definition*
+add-macros-content    ::= 'add_macros' macro-definition*
+use-content           ::= 'use' catalog-key
+module-content        ::= 'module' module-name macro-table? symbol-table?
+import-content        ::= 'import' module-name catalog-key
+encoding-content      ::= 'encoding' module-name*
+```
 
 ### Modules
 ```bnf
-module-body             ::= import* inner-module* macro-table? symbol-table? 
-
-shared-module           ::= '$ion_shared_module::' ivm '::(' catalog-key module-body ')'
-
-import                  ::= '(import ' module-name catalog-key ')'
-
 catalog-key             ::= catalog-name catalog-version?
 
 catalog-name            ::= string
 
-catalog-version         ::= unannotated-uint                   ; must be positive
-
-inner-module            ::= '(module' module-name module-body ')'
+catalog-version         ::= unannotated-uint
 
 module-name             ::= unannotated-identifier-symbol
 
@@ -53,64 +61,70 @@ symbol-text             ::= symbol | string
 
 macro-table             ::= '(macros' macro-table-entry* ')'
 
-macro-table-entry       ::= macro-definition
-                          | macro-export
-                          | module-name
-
-macro-export            ::= '(export' qualified-macro-ref macro-name-declaration? ')'
+macro-table-entry       ::= macro-definition-in-module | module-name
 ```
+
 ### Macro references
 ```bnf
 qualified-macro-ref     ::= module-name '::' macro-ref
 
 macro-ref               ::= macro-name | macro-addr
 
-qualified-macro-name    ::= module-name '::' macro-name
-
 macro-name              ::= unannotated-identifier-symbol
 
-macro-addr              ::= unannotated-uint 
+macro-addr              ::= unannotated-uint
+
+any-macro-ref-encoding  ::= macro-ref | qualified-macro-ref
 ```
 
 ### Macro definitions
 ```bnf
-macro-definition        ::= '(macro' macro-name-declaration signature tdl-expression ')'
+macro-name-declaration     ::= macro-name | 'null'
+macro-definition           ::= '(' macro-definition-contents ')'
+macro-definition-in-module ::= '(macro' macro-definition-contents ')'
+macro-definition-contents  ::= macro-name-declaration value-with-placeholders ; This prohibits "identity" macros
 
-macro-name-declaration  ::= macro-name | 'null'
+value-or-placeholder       ::= value-with-placeholders | placeholder
+list-with-placeholders     ::= '[' value-or-placeholder* ']' ; Note: for brevity, this grammar avoids comma handling
+sexp-with-placeholders     ::= '(' value-or-placeholder* ')'
+field-value-or-placeholder ::= symbol-text ':' value-or-placeholder
+struct-with-placeholders   ::= '{' field-value-or-placeholder* }
+value-with-placeholders    ::= value | list-with-placeholders | sexp-with-placeholders | struct-with-placeholders
 
-signature               ::= '(' parameter* ')'
+primitive-encoding-type    ::= 'int' | 'int8' |  'int16' |  'int32' |  'int64'
+                             | 'uint' | 'uint8' | 'uint16' | 'uint32' | 'uint64'
+                             | 'float16' | 'float32' | 'float64'
+                             | 'small_decimal'
+                             | 'timestamp_day' | 'timestamp_min' | 'timestamp_s'
+                             | 'timestamp_ms' | 'timestamp_us' | 'timestamp_ns'
+                             | 'symbol'
 
-parameter               ::= parameter-encoding? parameter-name parameter-cardinality?
+primitive-encoding-opcode  ::= '0x60' | '0x61' | '0x62' | '0x64' | '0x68'
+                             | '0xE0' | '0xE1' | '0xE2' | '0xE4' | '0xE8'
+                             | '0x6B' | '0x6C' | '0x6D'
+                             | '0x70'
+                             | '0x82' | '0x83' | '0x84'
+                             | '0x85' | '0x86' | '0x87'
+                             | '0xEE'
 
-parameter-encoding      ::= (primitive-encoding-type | qualified-primitive-type | macro-name | qualified-macro-name)'::'
+primitive-type-identifier  ::= primitive-encoding-type | primitive-encoding-opcode
+primitive-type-marker      ::= '{#' primitive-type-identifier '}'
+macro-type-marker          ::= '{:' any-macro-ref-encoding '}'
+any-type-marker-encoding   ::= primitive-type-marker | macro-type-marker
 
-qualified-primitive-type::= '$ion::' primitive-encoding-type
+placeholder                ::= tagged-placeholder | tagged-placeholder-default | tagless-placeholder
+tagged-placeholder         ::= '(:?)'
+tagged-placeholder-default ::= '(:? ' value ')'
+tagless-placeholder        ::= '(:? ' primitive-type-marker ')'
 
-primitive-encoding-type ::= 'uint8' | 'uint16' | 'uint32' | 'uint64'
-                          |  'int8' |  'int16' |  'int32' |  'int64'
-                          | 'float16' | 'float32' | 'float64'
-                          | 'flex_int' | 'flex_uint' 
-                          | 'flex_sym' | 'flex_string'
+tagless-element-list       ::= '[' any-type-marker-encoding value* ']'
+tagless-element-sexp       ::= '(' any-type-marker-encoding value* ')'
+```
 
-parameter-name          ::= unannotated-identifier-symbol
+### Macro invocations
 
-parameter-cardinality   ::= '!' | '*' | '?' | '+'
-
-tdl-expression          ::= operation | variable-expansion | ion-scalar | ion-container
-
-operation               ::= macro-invocation | special-form
-
-variable-expansion      ::= '(%' variable-name ')'
-
-variable-name           ::= unannotated-identifier-symbol
-
-macro-invocation        ::= '(.' macro-ref macro-arg* ')'
-
-special-form            ::= '(.' '$ion::'?  special-form-name tdl-expression* ')'
-
-special-form-name       ::= 'for' | 'if_none' | 'if_some' | 'if_single' | 'if_multi' | 'literal' | 'parse_ion '
-
-macro-arg               ::= tdl-expression | expression-group
-
-expression-group        ::= '(..' tdl-expression* ')'
+```bnf
+no-argument             ::= '(:)'
+macro-argument          ::= any-value-encoding | no-argument
+macro-invocation        ::= '(:' any-macro-ref-encoding macro-argument* ')'
 ```

--- a/_books/ion-1-1/src/grammar.md
+++ b/_books/ion-1-1/src/grammar.md
@@ -17,7 +17,7 @@ document           ::= ivm segment*
 
 ivm                ::= '$ion_1_1'
 
-any-value-encoding ::= value | macro-invocation | tagless-element-list | tagless-element-sexp
+any-value-encoding ::= value | e-expression | tagless-element-list | tagless-element-sexp
 
 segment            ::= any-value-encoding* directive?
 
@@ -79,6 +79,7 @@ any-macro-ref-encoding  ::= macro-ref | qualified-macro-ref
 
 ### Macro definitions
 ```bnf
+no-argument                ::= '(:)'
 macro-name-declaration     ::= macro-name | 'null'
 macro-definition           ::= '(' macro-definition-contents ')'
 macro-definition-in-module ::= '(macro' macro-definition-contents ')'
@@ -89,7 +90,10 @@ list-with-placeholders     ::= '[' value-or-placeholder* ']' ; Note: for brevity
 sexp-with-placeholders     ::= '(' value-or-placeholder* ')'
 field-value-or-placeholder ::= symbol-text ':' value-or-placeholder
 struct-with-placeholders   ::= '{' field-value-or-placeholder* }
-value-with-placeholders    ::= value | list-with-placeholders | sexp-with-placeholders | struct-with-placeholders
+argument-or-placeholder    ::= value-with-placeholders | no-argument | placeholder
+e-exp-with-placeholders    ::= '(:' any-macro-ref-encoding argument-or-placeholder* ')'
+value-with-placeholders    ::= value | list-with-placeholders | sexp-with-placeholders
+                             | struct-with-placeholders | e-exp-with-placeholders
 
 primitive-encoding-type    ::= 'int' | 'int8' |  'int16' |  'int32' |  'int64'
                              | 'uint' | 'uint8' | 'uint16' | 'uint32' | 'uint64'
@@ -99,32 +103,22 @@ primitive-encoding-type    ::= 'int' | 'int8' |  'int16' |  'int32' |  'int64'
                              | 'timestamp_ms' | 'timestamp_us' | 'timestamp_ns'
                              | 'symbol'
 
-primitive-encoding-opcode  ::= '0x60' | '0x61' | '0x62' | '0x64' | '0x68'
-                             | '0xE0' | '0xE1' | '0xE2' | '0xE4' | '0xE8'
-                             | '0x6B' | '0x6C' | '0x6D'
-                             | '0x70'
-                             | '0x82' | '0x83' | '0x84'
-                             | '0x85' | '0x86' | '0x87'
-                             | '0xEE'
-
-primitive-type-identifier  ::= primitive-encoding-type | primitive-encoding-opcode
-primitive-type-marker      ::= '{#' primitive-type-identifier '}'
+primitive-type-marker      ::= '{#' primitive-encoding-type '}'
 macro-type-marker          ::= '{:' any-macro-ref-encoding '}'
 any-type-marker-encoding   ::= primitive-type-marker | macro-type-marker
 
 placeholder                ::= tagged-placeholder | tagged-placeholder-default | tagless-placeholder
 tagged-placeholder         ::= '(:?)'
-tagged-placeholder-default ::= '(:? ' value ')'
+tagged-placeholder-default ::= '(:? ' any-value-encoding ')'
 tagless-placeholder        ::= '(:? ' primitive-type-marker ')'
 
 tagless-element-list       ::= '[' any-type-marker-encoding value* ']'
 tagless-element-sexp       ::= '(' any-type-marker-encoding value* ')'
 ```
 
-### Macro invocations
+### E-expressions
 
 ```bnf
-no-argument             ::= '(:)'
-macro-argument          ::= any-value-encoding | no-argument
-macro-invocation        ::= '(:' any-macro-ref-encoding macro-argument* ')'
+argument            ::= any-value-encoding | no-argument
+e-expression        ::= '(:' any-macro-ref-encoding argument* ')'
 ```

--- a/_books/ion-1-1/src/modules/defining_modules.md
+++ b/_books/ion-1-1/src/modules/defining_modules.md
@@ -42,18 +42,14 @@ Most commonly, a macro table entry is a definition of a new macro expansion func
 When the value `null` is given for the macro name, this defines an anonymous macro that can be referenced by its numeric
 address (that is, its index in the enclosing macro table).
 
-Module names and `export` clauses can be intermingled with `macro` definitions inside the `macros` clause;
+Module names can be intermingled with `macro` definitions inside the `macros` clause;
 together, they determine the bindings that make up the module’s exported macro array.
 
 The _module-name_ export form is shorthand for referencing all exported macros from that module,
 in their original order with their original names.
 
-An `export` clause contains a single macro reference followed by an optional alias for the exported macro.
-The referenced macro is appended to the macro table.
-
 > [!TIP]
 > No name can be repeated among the exported macros, including macro definitions.
-> Name conflicts must be resolved by `export`s with aliases.
 
 #### Processing
 
@@ -61,8 +57,6 @@ When the `macros` clause is encountered, the reader constructs an empty list. Th
 
 For each `arg`:
 * **If the `arg` is a `macro` clause**, the clause is processed and the resulting macro definition is appended 
-  to the end of the macro table being constructed.
-* **If the `arg` is an `export` clause**, the clause is processed and the referenced macro definition is appended 
   to the end of the macro table being constructed.
 * **If the `arg` is the name of a module**, the macro definitions in that module's macro table are appended
   to the end of the macro table being constructed.
@@ -79,20 +73,6 @@ If a macro is added whose name conflicts with one already present in the table, 
 
 A `macro` clause [defines a new macro](../macros/defining_macros.md).
 When the macro declaration uses a name, an error must be signaled if it already appears in the exported macro array.
-
-#### `export`
-
-An `export` clause declares a name for an existing macro and appends the macro to the macro table.
-* If the reference to the existing macro is followed by a name, the existing macro is appended to the exported
-  macro array with the latter name instead of the original name, if any.
-  In this way, an anonymous macro can be given a name.
-  An error must be signaled if that name already appears in the exported macro array.
-* If the reference to the existing macro is followed by `null`, the macro is appended to the exported macro array 
-  without a name, regardless of whether the macro has a name.
-* If the reference to the existing macro is anonymous, the macro is appended to the exported macro array without a name.
-* When the reference to the existing macro uses a name, the name and macro are appended to the exported macro  
-  array. An error must be signaled if that name already appears in the exported macro array.
-
 
 #### Module names in `macros`
 A module name appends all exported macros from the module to the exported macro array.

--- a/_books/ion-1-1/src/text/e_expressions.md
+++ b/_books/ion-1-1/src/text/e_expressions.md
@@ -65,6 +65,5 @@ Examples:
  * named macro-shape: `{:foo}`, `{:foo_module::bar_macro}`. May only be used in tagless-element sequences.
  * macro-shape by id: `{:12}`, `{:493}`. May only be used in tagless-element sequences.
  * tagless scalar type by name: `{#int}`, `{#uint8}`, `{#string}`, `{#symbol}`, `{#timestamp}`. May be used in tagless-element sequences or tagless template placeholders.
- * tagless scalar type by opcode: `{#0x61}`, `{#0xEE}`. May be used in tagless-element sequences or tagless template placeholders.
 
 Macros that accept 0 arguments are not eligible to be used in a type marker.


### PR DESCRIPTION
### Issue #, if available:
#397 

### Description of changes:
This grammar was never exhaustive, but I tried to maintain about the same level of exhaustiveness as before. The biggest assumption here is that there is a variable called `value` that defines the grammar for any Ion value literal.

This should more or less align the grammar with the simplified Ion 1.1 spec, but I would appreciate any comments on correctness, factoring, or things I forgot.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
