### PR TITLE
Prohibits macro names from beginning with '$'.

### DIFF
--- a/_books/ion-1-1/src/grammar.md
+++ b/_books/ion-1-1/src/grammar.md
@@ -61,7 +61,7 @@ symbol-text             ::= symbol | string
 
 macro-table             ::= '(macros' macro-table-entry* ')'
 
-macro-table-entry       ::= macro-definition-in-module | module-name
+macro-table-entry       ::= macro-definition | module-name
 ```
 
 ### Macro references
@@ -81,15 +81,13 @@ any-macro-ref-encoding  ::= macro-ref | qualified-macro-ref
 ```bnf
 no-argument                ::= '(:)'
 macro-name-declaration     ::= macro-name | 'null'
-macro-definition           ::= '(' macro-definition-contents ')'
-macro-definition-in-module ::= '(macro' macro-definition-contents ')'
-macro-definition-contents  ::= macro-name-declaration value-with-placeholders ; This prohibits "identity" macros
+macro-definition           ::= '(' macro-name-declaration value-with-placeholders ')' ; This prohibits "identity" macros
 
 value-or-placeholder       ::= value-with-placeholders | placeholder
 list-with-placeholders     ::= '[' value-or-placeholder* ']' ; Note: for brevity, this grammar avoids comma handling
 sexp-with-placeholders     ::= '(' value-or-placeholder* ')'
 field-value-or-placeholder ::= symbol-text ':' value-or-placeholder
-struct-with-placeholders   ::= '{' field-value-or-placeholder* }
+struct-with-placeholders   ::= '{' field-value-or-placeholder* '}'
 argument-or-placeholder    ::= value-with-placeholders | no-argument | placeholder
 e-exp-with-placeholders    ::= '(:' any-macro-ref-encoding argument-or-placeholder* ')'
 value-with-placeholders    ::= value | list-with-placeholders | sexp-with-placeholders

--- a/_books/ion-1-1/src/macros/defining_macros.md
+++ b/_books/ion-1-1/src/macros/defining_macros.md
@@ -27,7 +27,6 @@ Macros are defined within directives like `set_macros` or `add_macros`, or in [m
 
 The lexical name given to a macro must be an [identifier](../modules.md#identifiers).
 However, it must not begin with a `$`—this is reserved for system-defined bindings like `$ion`.
-Each macro name in a macro table must be unique.
 
 In some circumstances, it may not make sense to name a macro. (For example, when the macro is generated automatically.)
 In such cases, authors must use `null` to indicate that the macro does not have a name.

--- a/_books/ion-1-1/src/macros/defining_macros.md
+++ b/_books/ion-1-1/src/macros/defining_macros.md
@@ -25,7 +25,9 @@ Macros are defined within directives like `set_macros` or `add_macros`, or in [m
 
 ## Macro names
 
-Syntactically, macro names are [identifiers](../text/symbol-tokens.md). Each macro name in a macro table must be unique.
+The lexical name given to a macro must be an [identifier](../modules.md#identifiers).
+However, it must not begin with a `$`—this is reserved for system-defined bindings like `$ion`.
+Each macro name in a macro table must be unique.
 
 In some circumstances, it may not make sense to name a macro. (For example, when the macro is generated automatically.)
 In such cases, authors must use `null` to indicate that the macro does not have a name.

--- a/_books/ion-1-1/src/modules/defining_modules.md
+++ b/_books/ion-1-1/src/modules/defining_modules.md
@@ -6,7 +6,7 @@ A module is defined by two kinds of subclauses which, if present, always appear 
 2. `symbols` - an exported list of text values
 
 The lexical name given to a module definition must be an [identifier](../modules.md#identifiers).
-However, it must not begin with a `$`--this is reserved for system-defined bindings like `$ion`.
+However, it must not begin with a `$`—this is reserved for system-defined bindings like `$ion`.
 
 ### Internal environment
 

--- a/_books/ion-1-1/src/modules/defining_modules.md
+++ b/_books/ion-1-1/src/modules/defining_modules.md
@@ -42,7 +42,7 @@ Most commonly, a macro table entry is a definition of a new macro expansion func
 When the value `null` is given for the macro name, this defines an anonymous macro that can be referenced by its numeric
 address (that is, its index in the enclosing macro table).
 
-Module names can be intermingled with `macro` definitions inside the `macros` clause;
+Module names can be intermingled with macro definition s-expressions inside the `macros` clause;
 together, they determine the bindings that make up the module’s exported macro array.
 
 The _module-name_ export form is shorthand for referencing all exported macros from that module,
@@ -56,7 +56,7 @@ in their original order with their original names.
 When the `macros` clause is encountered, the reader constructs an empty list. The arguments to the clause are then processed from left to right.
 
 For each `arg`:
-* **If the `arg` is a `macro` clause**, the clause is processed and the resulting macro definition is appended 
+* **If the `arg` is an s-expression**, it is processed as a macro definition, which is appended
   to the end of the macro table being constructed.
 * **If the `arg` is the name of a module**, the macro definitions in that module's macro table are appended
   to the end of the macro table being constructed.
@@ -69,9 +69,9 @@ When a name is used, it must be an identifier per Ion’s syntax for symbols.
 Macro definitions being added to the macro table must have a unique name.
 If a macro is added whose name conflicts with one already present in the table, the implementation must raise an error.
 
-#### `macro`
+#### S-expressions in `macros`
 
-A `macro` clause [defines a new macro](../macros/defining_macros.md).
+An s-expression in `macros` [defines a new macro](../macros/defining_macros.md).
 When the macro declaration uses a name, an error must be signaled if it already appears in the exported macro array.
 
 #### Module names in `macros`

--- a/_books/ion-1-1/src/modules/encoding_modules.md
+++ b/_books/ion-1-1/src/modules/encoding_modules.md
@@ -125,7 +125,7 @@ $ion_1_1
 
 (:$ion module _
     (macros
-        (foo () Foo)))
+        (foo Foo)))
 
 // `_` now contains macro `foo`
 

--- a/_books/ion-1-1/src/modules/encoding_modules.md
+++ b/_books/ion-1-1/src/modules/encoding_modules.md
@@ -132,7 +132,7 @@ $ion_1_1
 (:$ion module _
     (macros
         _ // Add all macros in `_` to its redefinition
-        (bar () Bar)))
+        (bar Bar)))
 
 // `_` now contains macros `foo` and `bar`
 

--- a/_books/ion-1-1/src/modules/encoding_modules.md
+++ b/_books/ion-1-1/src/modules/encoding_modules.md
@@ -149,8 +149,8 @@ $ion_1_1
 // `_` exists, but is empty
 
 (:$ion add_macros
-    (foo () Foo)
-    (bar () Bar))
+    (foo Foo)
+    (bar Bar))
 
 // `_` now contains macros `foo` and `bar`
 

--- a/_books/ion-1-1/src/modules/encoding_modules.md
+++ b/_books/ion-1-1/src/modules/encoding_modules.md
@@ -125,14 +125,14 @@ $ion_1_1
 
 (:$ion module _
     (macros
-        (macro foo () Foo)))
+        (foo () Foo)))
 
 // `_` now contains macro `foo`
 
 (:$ion module _
     (macros
         _ // Add all macros in `_` to its redefinition
-        (macro bar () Bar)))
+        (bar () Bar)))
 
 // `_` now contains macros `foo` and `bar`
 
@@ -149,8 +149,8 @@ $ion_1_1
 // `_` exists, but is empty
 
 (:$ion add_macros
-    (macro foo () Foo)
-    (macro bar () Bar))
+    (foo () Foo)
+    (bar () Bar))
 
 // `_` now contains macros `foo` and `bar`
 
@@ -179,15 +179,15 @@ For example after these directives are evaluated:
 ```ion
 (:$ion module mod_a
     (macros
-        (macro foo Foo)
-        (macro bar Bar)))
+        (foo Foo)
+        (bar Bar)))
 
 (:$ion module mod_b)
 
 (:$ion module mod_c
     (macros
-        (macro quux Quux)
-        (macro quuz Quuz)))
+        (quux Quux)
+        (quuz Quuz)))
 
 (:$ion encoding mod_a mod_b mod_c)
 ```
@@ -205,7 +205,7 @@ If we then add macros to `mod_b`, those macros will immediately become available
 ```ion
 (:$ion module mod_b
     (macros
-        (macro baz () Baz)))
+        (baz () Baz)))
 
 (:0) // => Foo
 (:1) // => Bar

--- a/_books/ion-1-1/src/modules/encoding_modules.md
+++ b/_books/ion-1-1/src/modules/encoding_modules.md
@@ -205,7 +205,7 @@ If we then add macros to `mod_b`, those macros will immediately become available
 ```ion
 (:$ion module mod_b
     (macros
-        (baz () Baz)))
+        (baz Baz)))
 
 (:0) // => Foo
 (:1) // => Bar

--- a/_books/ion-1-1/src/modules/local_modules.md
+++ b/_books/ion-1-1/src/modules/local_modules.md
@@ -11,7 +11,7 @@ Stream-level bindings are mutable.
 ```ion
 (:$ion module foo // <-- Top-level module `foo`
   (macros
-    (quux () Quux)))
+    (quux Quux)))
 
 (:$ion module foo // <-- Redefines the top-level binding `foo`
   (macros

--- a/_books/ion-1-1/src/modules/local_modules.md
+++ b/_books/ion-1-1/src/modules/local_modules.md
@@ -11,11 +11,11 @@ Stream-level bindings are mutable.
 ```ion
 (:$ion module foo // <-- Top-level module `foo`
   (macros
-    (macro quux () Quux)))
+    (quux () Quux)))
 
 (:$ion module foo // <-- Redefines the top-level binding `foo`
   (macros
-    (macro quuz () Quuz)))
+    (quuz () Quuz)))
 ```
 
 Local modules inherit their spec version from the enclosing scope.

--- a/_books/ion-1-1/src/modules/local_modules.md
+++ b/_books/ion-1-1/src/modules/local_modules.md
@@ -15,7 +15,7 @@ Stream-level bindings are mutable.
 
 (:$ion module foo // <-- Redefines the top-level binding `foo`
   (macros
-    (quuz () Quuz)))
+    (quuz Quuz)))
 ```
 
 Local modules inherit their spec version from the enclosing scope.


### PR DESCRIPTION
### Description of changes:
Prohibits user macro names from starting with `$`. This is also prohibited in module names.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
