### PR TITLE
Clarifies that Ion 1.0 symbol table syntax is a no-op in Ion 1.1.

### DIFF
--- a/_books/ion-1-1/src/modules/directives.md
+++ b/_books/ion-1-1/src/modules/directives.md
@@ -166,6 +166,6 @@ When the version is not provided, a default value of 1 is used.
 
 ## Ion 1.0 symbol table syntax not supported
 
-In Ion 1.1 streams, Ion 1.0 symbol table syntax (`$ion_symbol_table::{...}`) is not supported.
+In Ion 1.1 streams, Ion 1.0 symbol table syntax (for example, `$ion_symbol_table::{...}`) is not supported.
 Ion 1.1 writers should not write such an annotated struct at the top level; Ion 1.1 readers
 must treat such an annotated struct as a no-op at the top level.

--- a/_books/ion-1-1/src/modules/directives.md
+++ b/_books/ion-1-1/src/modules/directives.md
@@ -163,3 +163,9 @@ When the version is not provided, a default value of 1 is used.
 // Defaults to version 1
 (:$ion use "com.example.geometry")
 ```
+
+## Ion 1.0 symbol table syntax not supported
+
+In Ion 1.1 streams, Ion 1.0 symbol table syntax (`$ion_symbol_table::{...}`) is not supported.
+Ion 1.1 writers should not write such an annotated struct at the top level; Ion 1.1 readers
+must treat such an annotated struct as a no-op at the top level.

--- a/_books/ion-1-1/src/whats_new.md
+++ b/_books/ion-1-1/src/whats_new.md
@@ -121,6 +121,8 @@ In Ion v1.1, there are eight supported directive operations:
 7. [`import`](modules/directives.md#import-directives)
 8. [`encoding`](modules/directives.md#encoding-directives)
 
+In Ion 1.1, directives must be used to modify the symbol or macro table. Ion 1.0 symbol table syntax is not supported.
+
 ### Shared Modules
 
 Ion 1.1 extends the concept of a _shared symbol table_ to be a _shared module_. An Ion 1.0 shared symbol table is a


### PR DESCRIPTION
### Description of changes:
Only directives may be used to modify the encoding context in Ion 1.1.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
