### PR TITLE
Fixes tagless encoding details

### DIFF
--- a/_books/ion-1-1/src/macros/tagless_encodings.md
+++ b/_books/ion-1-1/src/macros/tagless_encodings.md
@@ -7,23 +7,32 @@ Consider the following data:
 ```ion
 [
   { sum: 123, sample_count: 12 },
-  { sum: 54, sample_count: 8 },
+  { sum:  54, sample_count:  8 },
   { sum: 125, sample_count: 15 },
   { sum: 314, sample_count: 30 },
 ]
 ```
-With a macro such as `(metric {sum: (:? {#int}), sample_count: (:? {#int}), unit: ms})`, it can be encoded
-using a tagless-element list as follows
+With a macro such as `(metric {sum: (:? {#int}), sample_count: (:? {#int}), unit: ms})`, it can be encoded more compactly:
+```ion
+[
+  (:metric 123 12),
+  (:metric  54  8),
+  (:metric 125 15),
+  (:metric 314 30),
+]
+```
+We can increase the compactness even more using a tagless-element list as follows:
 ```ion
 [{:metric} // {:<macro_name>} specifies a macro-shape
   (123 12),
-  (54 8),
+  ( 54  8),
   (125 15),
   (314 30),
 ]
 ```
 
-The available tagless encodings are enumerated in the following table.
+Both primitive and macro-shape encodings may be used in tagless-element sequences, only the primitive encodings in the below table
+may be used in tagless template placeholders.
 
 | Ion Type    | Encoding Name   | Size in bytes | Binary Encoding Tag | Encoding                                                                        |
 |-------------|:----------------|:-------------:|:-------------------:|:--------------------------------------------------------------------------------|
@@ -49,5 +58,17 @@ The available tagless encodings are enumerated in the following table.
 |             | `timestamp_ns`  |       8       |       `0x87`        | [Nanosecond precision timestamp][t6]                                            |
 | `symbol`    | `symbol`        |   variable    |       `0xEE`        | [`FlexSym`][flexsym]                                                            |
 
-Although both primitive and macro-shape encodings may be used in tagless-element sequences, only the primitive encodings in the above table
-may be used in tagless template placeholders.
+[flexint]: ../binary/primitives/flex_int.md
+[fixedint]: ../binary/primitives/fixed_int.md
+[flexuint]: ../binary/primitives/flex_int.md
+[fixeduint]: ../binary/primitives/fixed_int.md
+[flexsym]: ../binary/primitives/flex_sym.md
+[f16]: https://en.wikipedia.org/wiki/Half-precision_floating-point_format
+[f32]: https://en.wikipedia.org/wiki/Single-precision_floating-point_format
+[f64]: https://en.wikipedia.org/wiki/Double-precision_floating-point_format
+[t1]: ../binary/values/timestamp.md#encoding-of-a-timestamp-with-day-precision
+[t2]: ../binary/values/timestamp.md#encoding-of-a-timestamp-with-hour-and-minutes-precision-at-utc-or-unknown-offset
+[t3]: ../binary/values/timestamp.md#encoding-of-a-timestamp-with-seconds-precision-at-utc-or-unknown-offset
+[t4]: ../binary/values/timestamp.md#encoding-of-a-timestamp-with-milliseconds-precision-at-utc-or-unknown-offset
+[t5]: ../binary/values/timestamp.md#encoding-of-a-timestamp-with-microseconds-precision-at-utc-or-unknown-offset
+[t6]: ../binary/values/timestamp.md#encoding-of-a-timestamp-with-nanoseconds-precision-at-utc-or-unknown-offset

--- a/_books/ion-1-1/src/macros/tagless_encodings.md
+++ b/_books/ion-1-1/src/macros/tagless_encodings.md
@@ -31,7 +31,7 @@ We can increase the compactness even more using a tagless-element list as follow
 ]
 ```
 
-Both primitive and macro-shape encodings may be used in tagless-element sequences, only the primitive encodings in the below table
+Both primitive and macro-shape encodings may be used in tagless-element sequences; only the primitive encodings in the below table
 may be used in tagless template placeholders.
 
 | Ion Type    | Encoding Name   | Size in bytes | Binary Encoding Tag | Encoding                                                                        |
@@ -60,8 +60,8 @@ may be used in tagless template placeholders.
 
 [flexint]: ../binary/primitives/flex_int.md
 [fixedint]: ../binary/primitives/fixed_int.md
-[flexuint]: ../binary/primitives/flex_int.md
-[fixeduint]: ../binary/primitives/fixed_int.md
+[flexuint]: ../binary/primitives/flex_uint.md
+[fixeduint]: ../binary/primitives/fixed_uint.md
 [flexsym]: ../binary/primitives/flex_sym.md
 [f16]: https://en.wikipedia.org/wiki/Half-precision_floating-point_format
 [f32]: https://en.wikipedia.org/wiki/Single-precision_floating-point_format

--- a/_books/ion-1-1/src/text/values.md
+++ b/_books/ion-1-1/src/text/values.md
@@ -478,11 +478,11 @@ Macros that accept 0 arguments may not be used as a macro-shape type for a tagle
 
 Examples:
 ```ion
-[{#int8} 1, 2, 3, 4]
-[{:point} (1 3), (1 4), (2 4)]
-[{:12} (1 3), (1 4), (2 4)]
-({:foo})                   // An empty s-expression with macro-shaped elements 
-[{#int8} 1, 2, 3, foo::4]  // ERROR: tagless elements cannot have annotations
+[{#int8} 1, 2, 3, 4]                // A primitive-typed tagless-element list
+[{:point} (1 3), (1 4), (2 4)]      // A "macro-shaped" tagless element list
+[{:12} (1 3), (1 4), (2 4)]         // The same list, but using the macro ID instead of the name
+({:foo})                            // An empty s-expression with macro-shaped elements 
+[{#int8} 1, 2, 3, foo::4]           // ERROR: tagless elements cannot have annotations
 ```
 
 ## Structs

--- a/_books/ion-1-1/src/text/values.md
+++ b/_books/ion-1-1/src/text/values.md
@@ -480,8 +480,8 @@ Examples:
 ```ion
 [{#int8} 1, 2, 3, 4]
 [{:point} (1 3), (1 4), (2 4)]
-({#0x60} 1 -2 3 -99999999999999999999999)
-({:foo})                   // An empty, macro-shaped s-expression
+[{:12} (1 3), (1 4), (2 4)]
+({:foo})                   // An empty s-expression with macro-shaped elements 
 [{#int8} 1, 2, 3, foo::4]  // ERROR: tagless elements cannot have annotations
 ```
 


### PR DESCRIPTION
### Issue #, if available:

None

### Description of changes:

* Fixes links on the tagless encoding table
* Clarifies wording in a few spots
* Removes example of using binary opcodes for primitives in text encoding
* Adds an example of using macro ID in the text encoding
* Elaborates how both tagless placeholders and tagless-element sequences can be used to increase compactness.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
